### PR TITLE
Use v3 codecov-action and upload-artifact, replace set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
   cs:
     uses: bedita/github-workflows/.github/workflows/php-cs.yml@v1
     with:
-      php_versions: '["7.4", "8.0", "8.1"]'
+      php_versions: '["7.4", "8.1", "8.2"]'
 
   stan:
     uses: bedita/github-workflows/.github/workflows/php-stan.yml@v1
@@ -48,7 +48,7 @@ jobs:
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
+        run: echo "path=$(composer global config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v2'
@@ -72,13 +72,13 @@ jobs:
           filename: 'clover.xml'
 
       - name: 'Export coverage results'
-        uses: 'codecov/codecov-action@v1'
+        uses: 'codecov/codecov-action@v3'
         with:
-          file: './clover.xml'
+          files: './clover.xml'
           env_vars: PHP_VERSION
 
       - name: 'Archive code coverage results'
-        uses: 'actions/upload-artifact@v2'
+        uses: 'actions/upload-artifact@v3'
         with:
           name: 'PHP ${{ matrix.php }}'
           path: 'clover.xml'


### PR DESCRIPTION
This PR fixes some deprecations in test github workflow, by updating the following:

 - codecov/codecov-action@v3
 - actions/upload-artifact@v3

Furthermore `set-output` is replaced with `GITHUB_OUTPUT`

Refs
====

Check coding style
-------------------------
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Static code analyzer
---------------------------
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Run unit tests (8.1, {"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image...
--------------------------------------------------------------------------------------------------------------------------
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: codecov/codecov-action@v1, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
