### PR TITLE
Add `FileTrait`, refactor `CsvTrait` and tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,14 @@ name: Release
 on:
   pull_request_target:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: 'Release type'
+        required: true
+        default: 'patch'
+        type: choice
+        options: [patch, minor, major]
 
 jobs:
   release-job:
@@ -10,3 +18,4 @@ jobs:
     with:
       main_branch: 'main'
       dist_branches: '["main"]'
+      version_bump: ${{ inputs.releaseType }}

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "cakephp/cakephp": "^4.2.2"
     },
     "require-dev": {
+        "bedita/core": "^5.0.0",
         "cakephp/cakephp-codesniffer": "~4.5.1",
         "phpstan/phpstan": "^1.8",
         "phpstan/extension-installer": "^1.0",

--- a/src/Utility/FileTrait.php
+++ b/src/Utility/FileTrait.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\ImportTools\Utility;
+
+use BEdita\Core\Filesystem\FilesystemRegistry;
+
+/**
+ * Utilities to help reading files from either the local filesystem or an adapter configured in BEdita.
+ */
+trait FileTrait
+{
+    /**
+     * Open read-only file stream. Possible sources are:
+     *  - `-` for STDIN
+     *  - local paths
+     *  - any URL supported by a registered PHP stream wrapper — notably, remote URLs via HTTP(S)
+     *  - (if `bedita/core` is available) any mountpoint registered in `FilesystemRegistry`
+     *
+     * @param string $path Path to open file from.
+     * @return array{resource, callable(): void}
+     */
+    protected static function readFileStream(string $path): array
+    {
+        /**
+         * Create a function to close the requested resource.
+         *
+         * @param resource|null $fh Resource to be closed.
+         * @return callable(): void Function to be used for closing the resource.
+         */
+        $closerFactory = fn ($resource): callable => function () use ($resource): void {
+            if (is_resource($resource)) {
+                fclose($resource);
+            }
+        };
+
+        if ($path === '-') {
+            return [STDIN, $closerFactory(null)]; // We don't really want to close STDIN.
+        }
+
+        if (!str_contains($path, '://') || in_array(explode('://', $path, 2)[0], stream_get_wrappers(), true)) {
+            try {
+                $fh = fopen($path, 'rb');
+                if ($fh === false) {
+                    trigger_error(sprintf('fopen(%s): falied to open stream', $path), E_USER_ERROR);
+                }
+            } catch (\Exception $previous) {
+                throw new \RuntimeException(sprintf('Cannot open file: %s', $path), 0, $previous);
+            }
+
+            return [$fh, $closerFactory($fh)];
+        }
+
+        if (!class_exists(FilesystemRegistry::class)) {
+            trigger_error(sprintf('Unsupported stream wrapper protocol: %s', $path), E_USER_ERROR);
+        }
+
+        $fh = FilesystemRegistry::getMountManager()->readStream($path);
+
+        return [$fh, $closerFactory($fh)];
+    }
+}

--- a/tests/TestCase/Utility/CsvTraitTest.php
+++ b/tests/TestCase/Utility/CsvTraitTest.php
@@ -15,13 +15,12 @@ declare(strict_types=1);
 namespace BEdita\ImportTools\Test\TestCase\Utility;
 
 use BEdita\ImportTools\Utility\CsvTrait;
-use Cake\Http\Exception\NotFoundException;
-use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * {@see \BEdita\ImportTools\Utility\CsvTrait} Test Case
  *
- * @coversDefaultClass \BEdita\ImportTools\Utility\CsvTrait
+ * @covers \BEdita\ImportTools\Utility\CsvTrait
  */
 class CsvTraitTest extends TestCase
 {
@@ -39,44 +38,36 @@ class CsvTraitTest extends TestCase
     ];
 
     /**
-     * Test `readCsv` method, NotFoundException
+     * Test `readCsv` method with a file that does not exist.
      *
      * @return void
-     * @covers ::readCsv()
      */
     public function testReadNotFound(): void
     {
-        $path = sprintf('%s/tests/files/not-found.csv', getcwd());
-        $expected = new NotFoundException(sprintf('File not found: %s', $path));
-        $this->expectException(get_class($expected));
-        $this->expectExceptionCode($expected->getCode());
-        $this->expectExceptionMessage($expected->getMessage());
-        $actual = [];
-        foreach ($this->readCsv($path) as $row) {
-            $actual[] = $row;
-        }
-        static::assertSame('Generator', get_class((object)$actual[0]));
+        $path = TEST_FILES . DS . 'not-found.csv';
+
+        $expected = new \RuntimeException(sprintf('Cannot open file: %s', $path));
+        $this->expectExceptionObject($expected);
+
+        $this->readCsv($path)->next();
     }
 
     /**
      * Test `readCsv` method
      *
      * @return void
-     * @covers ::readCsv()
      */
     public function testReadCsv(): void
     {
-        $path = sprintf('%s/tests/files/authors.csv', getcwd());
         $expected = [
             ['title' => 'The Great Gatsby', 'author' => 'Francis Scott Fitzgerald'],
             ['title' => 'Moby-Dick', 'author' => 'Herman Melville'],
             ['title' => 'Ulysses', 'author' => 'James Joyce'],
             ['title' => 'Hearth of Darkness', 'author' => 'Joseph Conrad'],
         ];
-        $actual = [];
-        foreach ($this->readCsv($path) as $row) {
-            $actual[] = $row;
-        }
+
+        $actual = iterator_to_array($this->readCsv(TEST_FILES . DS . 'authors.csv'));
+
         static::assertSame($expected, $actual);
     }
 }

--- a/tests/TestCase/Utility/FileTraitTest.php
+++ b/tests/TestCase/Utility/FileTraitTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\ImportTools\Test\TestCase\Utility;
+
+use BEdita\ImportTools\Utility\FileTrait;
+use League\Flysystem\UnableToReadFile;
+use League\Flysystem\UnableToResolveFilesystemMount;
+
+/**
+ * {@see \BEdita\ImportTools\Utility\FileTrait} Test Case
+ *
+ * @covers \BEdita\ImportTools\Utility\FileTrait
+ */
+class FileTraitTest extends \PHPUnit\Framework\TestCase
+{
+    use FileTrait;
+
+    /**
+     * Data provider for {@see FileTraitTest::testReadFileStream()} test case.
+     *
+     * @return array<string, array{string|\Exception, string}>
+     */
+    public function readFileStreamProvider(): array
+    {
+        $example = file_get_contents(TEST_FILES . DS . 'example.txt');
+
+        return [
+            'file (local)' => [$example, TEST_FILES . DS . 'example.txt'],
+            'file (`file://` stream wrapper)' => [$example, 'file://' . TEST_FILES . DS . 'example.txt'],
+            'file (filesystem registry)' => [$example, 'test-data://example.txt'],
+            'file not found (local)' => [
+                new \RuntimeException(sprintf('Cannot open file: %s', TEST_FILES . DS . 'not-found.csv')),
+                TEST_FILES . DS . 'not-found.csv',
+            ],
+            'file not found (filesystem registry)' => [
+                new UnableToReadFile('Unable to read file from location: test-data://not-found.csv.'),
+                'test-data://not-found.csv',
+            ],
+            'bad protocol (filesystem registry)' => [
+                new UnableToResolveFilesystemMount('Unable to resolve the filesystem mount because the mount (unregistered-protocol) was not registered.'),
+                'unregistered-protocol://example.txt',
+            ],
+        ];
+    }
+
+    /**
+     * Test {@see \BEdita\ImportTools\Utility\FileTrait::readFileStream()} method.
+     *
+     * @param string|\Exception $expected Expected outcome.
+     * @param string $path Path for input.
+     * @return void
+     * @dataProvider readFileStreamProvider()
+     */
+    public function testReadFileStream($expected, string $path): void
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectExceptionObject($expected);
+        }
+
+        $return = static::readFileStream($path);
+        static::assertCount(2, $return);
+        static::assertArrayHasKey(0, $return);
+        $stream = $return[0];
+        static::assertIsResource($stream);
+        static::assertIsNotClosedResource($stream);
+        static::assertArrayHasKey(1, $return);
+        $closingFn = $return[1];
+        static::assertIsCallable($closingFn);
+
+        $actual = stream_get_contents($stream);
+        static::assertSame($expected, $actual);
+
+        $closingFn();
+        static::assertIsClosedResource($stream);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,9 @@ declare(strict_types=1);
  * installed as a dependency of an application.
  */
 
+use BEdita\Core\Filesystem\Adapter\LocalAdapter;
+use BEdita\Core\Filesystem\FilesystemRegistry;
+
 $findRoot = function ($root) {
     do {
         $lastRoot = $root;
@@ -39,3 +42,11 @@ chdir($root);
 
 require_once 'vendor/cakephp/cakephp/src/basics.php';
 require_once 'vendor/autoload.php';
+
+const TEST_FILES = __DIR__ . DS . 'files';
+const WWW_ROOT = TEST_FILES; // Necessary to avoid warning when instantiating LocalAdapter.
+
+FilesystemRegistry::setConfig('test-data', [
+    'className' => LocalAdapter::class,
+    'path' => TEST_FILES,
+]);

--- a/tests/files/example.txt
+++ b/tests/files/example.txt
@@ -1,0 +1,1 @@
+This is an example text file


### PR DESCRIPTION
This PR adds a new `FileTrait` to help reading from input files stored either locally, available through a `FilesystemRegistry` mount point, from a PHP supported stream wrapper (such as HTTP(S) URLs), or from stdin when path is `-`.

The `CsvTrait` has been slightly refactored to use this trait instead of implementing its own logic.

It adds test cases for the new trait, and updates the release workflow to allow manual releases.

**Note:** there are two uncovered lines, which due to the fact that this repo has so little code decrease coverage by a relevant percentage. However, those cases are not easily unit-testable, as they either require stdin data to be provided or a particular dependency from being uninstalled.