### PR TITLE
Import Command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,13 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
-        "cakephp/cakephp": "^4.2.2"
+        "php": ">= 7.4",
+        "cakephp/cakephp": "^4.4"
     },
     "require-dev": {
-        "bedita/core": "^5.0.0",
-        "cakephp/cakephp-codesniffer": "~4.5.1",
+        "bedita/core": "^5.14",
+        "bedita/api": "^5.14",
+        "cakephp/cakephp-codesniffer": "~4.5",
         "phpstan/phpstan": "^1.8",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
@@ -38,7 +39,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "BEdita\\ImportTools\\Test\\": "tests",
+            "BEdita\\Core\\Test\\": "vendor/bedita/core/tests/",
+            "BEdita\\ImportTools\\Test\\": "tests/",
             "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
         }
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,7 +10,5 @@
 
     <config name="installed_paths" value="../../cakephp/cakephp-codesniffer"/>
 
-    <rule ref="CakePHP">
-        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes" />
-    </rule>
+    <rule ref="CakePHP"/>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,3 +5,5 @@ parameters:
     - src
     - tests
   level: 5
+  checkMissingIterableValueType: false
+  checkGenericClassInNonGenericObjectType: false

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="./tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">./src/</directory>
-    </include>
-  </coverage>
+<phpunit
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    bootstrap="./tests/bootstrap.php"
+    forceCoversAnnotation="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <php>
     <ini name="memory_limit" value="-1"/>
     <ini name="apc.enable_cli" value="1"/>
   </php>
-  <!-- Add any additional test suites you want to run here -->
   <testsuites>
     <testsuite name="BEdita/ImportTools">
       <directory>./tests/TestCase/</directory>
@@ -18,4 +19,9 @@
   <extensions>
     <extension class="\Cake\TestSuite\Fixture\PHPUnitExtension"/>
   </extensions>
+  <coverage>
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+  </coverage>
 </phpunit>

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -15,17 +15,12 @@ declare(strict_types=1);
 
 namespace BEdita\ImportTools\Command;
 
-use BEdita\Core\Model\Table\RolesTable;
-use BEdita\Core\Model\Table\UsersTable;
 use BEdita\Core\Utility\LoggedUser;
-use BEdita\ImportTools\Utility\CsvTrait;
-use BEdita\ImportTools\Utility\TreeTrait;
+use BEdita\ImportTools\Utility\Import;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Cake\Http\Exception\BadRequestException;
-use Cake\Utility\Hash;
 
 /**
  * Import command.
@@ -63,65 +58,6 @@ use Cake\Utility\Hash;
  */
 class ImportCommand extends Command
 {
-    use CsvTrait;
-    use TreeTrait;
-
-    /**
-     * @inheritDoc
-     */
-    protected $_defaultConfig = [
-        'defaults' => [
-            'status' => 'on',
-        ],
-        'csv' => [
-            'delimiter' => ',',
-            'enclosure' => '"',
-            'escape' => '"',
-        ],
-    ];
-
-    /**
-     * Dry run mode flag
-     *
-     * @var bool
-     */
-    protected bool $dryrun = false;
-
-    /**
-     * Full filename path
-     *
-     * @var string|null
-     */
-    protected ?string $filename = '';
-
-    /**
-     * Parent uname or ID
-     *
-     * @var string|null
-     */
-    protected ?string $parent = '';
-
-    /**
-     * Number of processed entities
-     *
-     * @var int
-     */
-    protected int $processed = 0;
-
-    /**
-     * Number of saved entities
-     *
-     * @var int
-     */
-    protected int $saved = 0;
-
-    /**
-     * Entity type
-     *
-     * @var string
-     */
-    protected string $type = '';
-
     /**
      * @inheritDoc
      */
@@ -157,132 +93,34 @@ class ImportCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {
-        $this->filename = $args->getOption('file');
-        if (!file_exists($this->filename)) {
-            $io->out(sprintf('Bad csv source file name "%s"', $this->filename));
+        $filename = $args->getOption('file');
+        if (!file_exists($filename)) {
+            $io->out(sprintf('Bad csv source file name "%s"', $filename));
 
             return;
         }
-        $this->type = $args->getOption('type');
-        $this->parent = $args->getOption('parent');
-        if ($args->getOption('dryrun')) {
-            $this->dryrun = true;
-        }
+        $type = $args->getOption('type');
+        $parent = $args->getOption('parent');
+        $dryrun = $args->getOption('dryrun') ? true : false;
         $io->out('---------------------------------------');
         $io->out('Start');
-        $io->out(sprintf('File: %s', $this->filename));
-        $io->out(sprintf('Type: %s', $this->type));
-        $io->out(sprintf('Parent: %s', empty($this->parent) ? 'none' : $this->parent));
-        $io->out(sprintf('Dry run mode: %s', $this->dryrun === true ? 'yes' : 'no'));
-        LoggedUser::setUser(['id' => UsersTable::ADMIN_USER, 'roles' => [['id' => RolesTable::ADMIN_ROLE]]]);
-        $method = $this->type !== 'translations' ? 'objects' : 'translations';
-        $this->$method();
-        $io->out(sprintf('Processed: %d, Saved: %d', $this->processed, $this->saved));
+        $io->out(sprintf('File: %s', $filename));
+        $io->out(sprintf('Type: %s', $type));
+        $io->out(sprintf('Parent: %s', empty($parent) ? 'none' : $parent));
+        $io->out(sprintf('Dry run mode: %s', $dryrun === true ? 'yes' : 'no'));
+        LoggedUser::setUserAdmin();
+        $import = new Import($filename, $type, $parent, $dryrun);
+        $method = $type !== 'translations' ? 'objects' : 'translations';
+        $import->$method();
+        $io->out(
+            sprintf(
+                'Processed: %d, Saved: %d, Errors: %d',
+                $import->processed,
+                $import->saved,
+                $import->errors
+            )
+        );
         $io->out('Done, bye!');
         $io->out('---------------------------------------');
-    }
-
-    /**
-     * Save objects
-     *
-     * @return void
-     */
-    protected function objects(): void
-    {
-        /** @var \BEdita\Core\Model\Table\ObjectsTable $objectsTable */
-        $objectsTable = $this->fetchTable('objects');
-        /** @var \BEdita\Core\Model\Table\ObjectsTable $table */
-        $table = $this->fetchTable($this->type);
-        foreach ($this->readCsv($this->filename) as $obj) {
-            $this->processed++;
-            $entity = $table->newEmptyEntity();
-            if (!empty($obj['uname'])) {
-                $uname = $obj['uname'];
-                if ($objectsTable->exists(compact('uname'))) {
-                    /** @var \BEdita\Core\Model\Entity\ObjectEntity $o */
-                    $o = $objectsTable->find()->where(compact('uname'))->firstOrFail();
-                    if ($o->type !== $this->type) {
-                        throw new BadRequestException(
-                            sprintf('Object uname "%s" already present with another type "%s"', $uname, $o->type)
-                        );
-                    }
-                    $entity = $table->get($table->getId($uname));
-                }
-            }
-            if ($this->dryrun === true) {
-                continue;
-            }
-            $entity = $table->patchEntity($entity, $obj);
-            $entity->set('type', $this->type);
-            $table->saveOrFail($entity);
-            if (isset($this->parent)) {
-                $this->setParent($entity, $this->parent);
-            }
-            $this->saved++;
-        }
-    }
-
-    /**
-     * Save translations
-     *
-     * @return void
-     */
-    protected function translations(): void
-    {
-        foreach ($this->readCsv($this->filename) as $translation) {
-            $this->processed++;
-            $this->translationFields($translation);
-            if ($this->dryrun === true) {
-                continue;
-            }
-            $this->saveTranslation($translation);
-            $this->saved++;
-        }
-    }
-
-    /**
-     * Setup translations fields
-     *
-     * @param array $translation Translation data
-     * @return void
-     */
-    protected function translationFields(array &$translation): void
-    {
-        $objectUname = (string)Hash::get($translation, 'object_uname');
-        /** @var \BEdita\Core\Model\Table\ObjectsTable $objectsTable */
-        $objectsTable = $this->fetchTable('Objects');
-        $objectId = $objectsTable->getId($objectUname);
-        /** @var \BEdita\Core\Model\Table\TranslationsTable $translationsTable */
-        $translationsTable = $this->fetchTable('Translations');
-        /** @var \BEdita\Core\Model\Entity\Translation $entity */
-        $entity = $translationsTable->find()
-            ->where([
-                'object_id' => $objectId,
-                'lang' => $translation['lang'],
-            ])
-            ->first();
-        if ($entity->id) {
-            $translation['id'] = $entity->id;
-        }
-        unset($translation['object_uname']);
-        $translation['object_id'] = $objectId;
-    }
-
-    /**
-     * Save translation
-     *
-     * @param array $translation Translation data
-     * @return void
-     */
-    protected function saveTranslation(array &$translation): void
-    {
-        $table = $this->fetchTable('Translations');
-        $entity = $table->newEntity($translation);
-        $entity->set('translated_fields', json_decode($translation['translated_fields'], true));
-        $entity->set('status', $this->getConfig('defaults')['status']);
-        if (!empty($translation['id'])) {
-            $entity->set('id', $translation['id']);
-        }
-        $table->saveOrFail($entity);
     }
 }

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -1,0 +1,279 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\ImportTools\Command;
+
+use BEdita\Core\Model\Table\RolesTable;
+use BEdita\Core\Model\Table\UsersTable;
+use BEdita\Core\Utility\LoggedUser;
+use BEdita\ImportTools\Utility\CsvTrait;
+use BEdita\ImportTools\Utility\TreeTrait;
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Http\Exception\BadRequestException;
+use Cake\Utility\Hash;
+
+/**
+ * Import command.
+ *
+ * $ bin/cake import --help
+ *
+ * Usage:
+ * cake import [options]
+ *
+ * Options:
+ *
+ * --dryrun, -d   dry run mode
+ * --file, -f     CSV file to import (required)
+ * --help, -h     Display this help.
+ * --parent, -p   destination folder uname
+ * --quiet, -q    Enable quiet output.
+ * --type, -t     entity type to import (required)
+ * --verbose, -v  Enable verbose output.
+ *
+ * # basic
+ * $ bin/cake import --file documents.csv --type documents
+ * $ bin/cake import -f documents.csv -t documents
+ *
+ * # dry-run
+ * $ bin/cake import --file articles.csv --type articles --dryrun yes
+ * $ bin/cake import -f articles.csv -t articles -d yes
+ *
+ * # destination folder
+ * $ bin/cake import --file news.csv --type news --parent my-folder-uname
+ * $ bin/cake import -f news.csv -t news -p my-folder-uname
+ *
+ * # translations
+ * $ bin/cake import --file translations.csv --type translations
+ * $ bin/cake import -f translations.csv -t translations
+ */
+class ImportCommand extends Command
+{
+    use CsvTrait;
+    use TreeTrait;
+
+    /**
+     * @inheritDoc
+     */
+    protected $_defaultConfig = [
+        'defaults' => [
+            'status' => 'on',
+        ],
+        'csv' => [
+            'delimiter' => ',',
+            'enclosure' => '"',
+            'escape' => '"',
+        ],
+    ];
+
+    /**
+     * Dry run mode flag
+     *
+     * @var bool
+     */
+    protected bool $dryrun = false;
+
+    /**
+     * Full filename path
+     *
+     * @var string|null
+     */
+    protected ?string $filename = '';
+
+    /**
+     * Parent uname or ID
+     *
+     * @var string|null
+     */
+    protected ?string $parent = '';
+
+    /**
+     * Number of processed entities
+     *
+     * @var int
+     */
+    protected int $processed = 0;
+
+    /**
+     * Number of saved entities
+     *
+     * @var int
+     */
+    protected int $saved = 0;
+
+    /**
+     * Entity type
+     *
+     * @var string
+     */
+    protected string $type = '';
+
+    /**
+     * @inheritDoc
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        $parser = parent::buildOptionParser($parser);
+        $parser->addOption('file', [
+                'help' => 'CSV file to import',
+                'required' => true,
+                'short' => 'f',
+            ])
+            ->addOption('type', [
+                'help' => 'entity type to import',
+                'required' => true,
+                'short' => 't',
+            ])
+            ->addOption('parent', [
+                'help' => 'destination folder uname',
+                'required' => false,
+                'short' => 'p',
+            ])
+            ->addOption('dryrun', [
+                'help' => 'dry run mode',
+                'required' => false,
+                'short' => 'd',
+            ]);
+
+        return $parser;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        $this->filename = $args->getOption('file');
+        if (!file_exists($this->filename)) {
+            $io->out(sprintf('Bad csv source file name "%s"', $this->filename));
+
+            return;
+        }
+        $this->type = $args->getOption('type');
+        $this->parent = $args->getOption('parent');
+        if ($args->getOption('dryrun')) {
+            $this->dryrun = true;
+        }
+        $io->out('---------------------------------------');
+        $io->out('Start');
+        $io->out(sprintf('File: %s', $this->filename));
+        $io->out(sprintf('Type: %s', $this->type));
+        $io->out(sprintf('Parent: %s', empty($this->parent) ? 'none' : $this->parent));
+        $io->out(sprintf('Dry run mode: %s', $this->dryrun === true ? 'yes' : 'no'));
+        LoggedUser::setUser(['id' => UsersTable::ADMIN_USER, 'roles' => [['id' => RolesTable::ADMIN_ROLE]]]);
+        $method = $this->type !== 'translations' ? 'objects' : 'translations';
+        $this->$method();
+        $io->out(sprintf('Processed: %d, Saved: %d', $this->processed, $this->saved));
+        $io->out('Done, bye!');
+        $io->out('---------------------------------------');
+    }
+
+    /**
+     * Save objects
+     *
+     * @return void
+     */
+    protected function objects(): void
+    {
+        $objectsTable = $this->fetchTable('objects');
+        $table = $this->fetchTable($this->type);
+        foreach ($this->readCsv($this->filename) as $obj) {
+            $this->processed++;
+            $entity = $table->newEmptyEntity();
+            if (!empty($obj['uname'])) {
+                $uname = $obj['uname'];
+                if ($objectsTable->exists(compact('uname'))) {
+                    /** @var \BEdita\Core\Model\Entity\ObjectEntity $o */
+                    $o = $objectsTable->find()->where(compact('uname'))->firstOrFail();
+                    if ($o->type !== $this->type) {
+                        throw new BadRequestException(
+                            sprintf('Object uname "%s" already present with another type "%s"', $uname, $o->type)
+                        );
+                    }
+                    $entity = $table->get($table->getId($uname));
+                }
+            }
+            if ($this->dryrun === true) {
+                continue;
+            }
+            $entity = $table->patchEntity($entity, $obj);
+            $entity->set('type', $this->type);
+            $table->saveOrFail($entity);
+            if (isset($this->parent)) {
+                $this->setParent($entity, $this->parent);
+            }
+            $this->saved++;
+        }
+    }
+
+    /**
+     * Save translations
+     *
+     * @return void
+     */
+    protected function translations(): void
+    {
+        foreach ($this->readCsv($this->filename) as $translation) {
+            $this->processed++;
+            $this->translationFields($translation);
+            if ($this->dryrun === true) {
+                continue;
+            }
+            $this->saveTranslation($translation);
+            $this->saved++;
+        }
+    }
+
+    /**
+     * Setup translations fields
+     *
+     * @param array $translation Translation data
+     * @return void
+     */
+    protected function translationFields(array &$translation): void
+    {
+        $objectUname = (string)Hash::get($translation, 'object_uname');
+        $objectEntity = $this->fetchTable('Objects')->find('unameId', [$objectUname])->firstOrFail();
+        $entity = $this->fetchTable('Translations')->find()->where([
+            'object_id' => $objectEntity->id,
+            'lang' => $translation['lang'],
+        ])->first();
+        if ($entity) {
+            $translation['id'] = $entity->id;
+        }
+        unset($translation['object_uname']);
+        $translation['object_id'] = $objectEntity->id;
+    }
+
+    /**
+     * Save translation
+     *
+     * @param array $translation Translation data
+     * @return void
+     */
+    protected function saveTranslation(array &$translation): void
+    {
+        $table = $this->fetchTable('Translations');
+        $entity = $table->newEntity($translation);
+        $entity->set('translated_fields', json_decode($translation['translated_fields'], true));
+        $entity->set('status', $this->getConfig('defaults')['status']);
+        if (!empty($translation['id'])) {
+            $entity->set('id', $translation['id']);
+        }
+        $table->saveOrFail($entity);
+    }
+}

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -93,14 +93,14 @@ class ImportCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {
-        $filename = $args->getOption('file');
+        $filename = (string)$args->getOption('file');
         if (!file_exists($filename)) {
             $io->out(sprintf('Bad csv source file name "%s"', $filename));
 
             return;
         }
-        $type = $args->getOption('type');
-        $parent = $args->getOption('parent');
+        $type = (string)$args->getOption('type');
+        $parent = (string)$args->getOption('parent');
         $dryrun = $args->getOption('dryrun') ? true : false;
         $io->out('---------------------------------------');
         $io->out('Start');

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -189,7 +189,9 @@ class ImportCommand extends Command
      */
     protected function objects(): void
     {
+        /** @var \BEdita\Core\Model\Table\ObjectsTable $objectsTable */
         $objectsTable = $this->fetchTable('objects');
+        /** @var \BEdita\Core\Model\Table\ObjectsTable $table */
         $table = $this->fetchTable($this->type);
         foreach ($this->readCsv($this->filename) as $obj) {
             $this->processed++;
@@ -247,16 +249,23 @@ class ImportCommand extends Command
     protected function translationFields(array &$translation): void
     {
         $objectUname = (string)Hash::get($translation, 'object_uname');
-        $objectEntity = $this->fetchTable('Objects')->find('unameId', [$objectUname])->firstOrFail();
-        $entity = $this->fetchTable('Translations')->find()->where([
-            'object_id' => $objectEntity->id,
-            'lang' => $translation['lang'],
-        ])->first();
-        if ($entity) {
+        /** @var \BEdita\Core\Model\Table\ObjectsTable $objectsTable */
+        $objectsTable = $this->fetchTable('Objects');
+        $objectId = $objectsTable->getId($objectUname);
+        /** @var \BEdita\Core\Model\Table\TranslationsTable $translationsTable */
+        $translationsTable = $this->fetchTable('Translations');
+        /** @var \BEdita\Core\Model\Entity\Translation $entity */
+        $entity = $translationsTable->find()
+            ->where([
+                'object_id' => $objectId,
+                'lang' => $translation['lang'],
+            ])
+            ->first();
+        if ($entity->id) {
             $translation['id'] = $entity->id;
         }
         unset($translation['object_uname']);
-        $translation['object_id'] = $objectEntity->id;
+        $translation['object_id'] = $objectId;
     }
 
     /**

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -106,8 +106,8 @@ class ImportCommand extends Command
         $io->out('Start');
         $io->out(sprintf('File: %s', $filename));
         $io->out(sprintf('Type: %s', $type));
-        $io->out(sprintf('Parent: %s', empty($parent) ? 'none' : $parent));
-        $io->out(sprintf('Dry run mode: %s', $dryrun === true ? 'yes' : 'no'));
+        $io->out(sprintf('Parent: %s', $parent));
+        $io->out(sprintf('Dry run mode: %s', (string)$dryrun));
         LoggedUser::setUserAdmin();
         $import = new Import($filename, $type, $parent, $dryrun);
         $method = $type !== 'translations' ? 'saveObjects' : 'saveTranslations';

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -114,9 +114,10 @@ class ImportCommand extends Command
         $import->$method();
         $io->out(
             sprintf(
-                'Processed: %d, Saved: %d, Errors: %d',
+                'Processed: %d, Saved: %d, Skipped: %d, Errors: %d',
                 $import->processed,
                 $import->saved,
+                $import->skipped,
                 $import->errors
             )
         );

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -110,7 +110,7 @@ class ImportCommand extends Command
         $io->out(sprintf('Dry run mode: %s', $dryrun === true ? 'yes' : 'no'));
         LoggedUser::setUserAdmin();
         $import = new Import($filename, $type, $parent, $dryrun);
-        $method = $type !== 'translations' ? 'objects' : 'translations';
+        $method = $type !== 'translations' ? 'saveObjects' : 'saveTranslations';
         $import->$method();
         $io->out(
             sprintf(

--- a/src/Utility/Import.php
+++ b/src/Utility/Import.php
@@ -272,9 +272,6 @@ class Import
         $entity->set('translated_fields', $this->translatedFields($data));
         $entity->set('status', $this->getConfig('defaults')['status']);
         $entity->set('lang', $data['lang']);
-        if (!empty($data['id'])) {
-            $entity->set('id', $data['id']);
-        }
         if ($this->dryrun === true) {
             $this->skipped++;
 

--- a/src/Utility/Import.php
+++ b/src/Utility/Import.php
@@ -296,9 +296,7 @@ class Import
     {
         $fields = (string)Hash::get($source, 'translated_fields');
         if (!empty($fields)) {
-            $fields = empty($fields) ? [] : json_decode($fields, true);
-
-            return $fields;
+            return json_decode($fields, true);
         }
         $fields = [];
         foreach ($source as $key => $value) {

--- a/src/Utility/Import.php
+++ b/src/Utility/Import.php
@@ -1,0 +1,314 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\ImportTools\Utility;
+
+use BEdita\Core\Model\Entity\ObjectEntity;
+use BEdita\Core\Model\Entity\Translation;
+use Cake\Http\Exception\BadRequestException;
+use Cake\Log\LogTrait;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\Utility\Hash;
+
+class Import
+{
+    use CsvTrait;
+    use LocatorAwareTrait;
+    use LogTrait;
+    use TreeTrait;
+
+    /**
+     * @inheritDoc
+     */
+    protected $_defaultConfig = [
+        'defaults' => [
+            'status' => 'on',
+        ],
+        'csv' => [
+            'delimiter' => ',',
+            'enclosure' => '"',
+            'escape' => '"',
+        ],
+    ];
+
+    /**
+     * Dry run mode flag
+     *
+     * @var bool
+     */
+    public bool $dryrun = false;
+
+    /**
+     * Full filename path
+     *
+     * @var string|null
+     */
+    public ?string $filename = '';
+
+    /**
+     * Parent uname or ID
+     *
+     * @var string|null
+     */
+    public ?string $parent = '';
+
+    /**
+     * Number of processed entities
+     *
+     * @var int
+     */
+    public int $processed = 0;
+
+    /**
+     * Number of saved entities
+     *
+     * @var int
+     */
+    public int $saved = 0;
+
+    /**
+     * Number of errors
+     *
+     * @var int
+     */
+    public int $errors = 0;
+
+    /**
+     * Errors details
+     *
+     * @var array
+     */
+    public array $errorsDetails = [];
+
+    /**
+     * Number of skipped
+     *
+     * @var int
+     */
+    public int $skipped = 0;
+
+    /**
+     * Entity type
+     *
+     * @var string
+     */
+    public string $type = '';
+
+    /**
+     * Objects table
+     *
+     * @var \BEdita\Core\Model\Table\ObjectsTable
+     */
+    protected $objectsTable;
+
+    /**
+     * Type table
+     *
+     * @var \BEdita\Core\Model\Table\ObjectsTable
+     */
+    protected $typeTable;
+
+    /**
+     * Translations table
+     *
+     * @var \BEdita\Core\Model\Table\TranslationsTable
+     */
+    protected $translationsTable;
+
+    /**
+     * Constructor
+     *
+     * @param string|null $filename Full filename path
+     * @param string|null $type Entity type
+     * @param string|null $parent Parent uname or ID
+     * @param bool|null $dryrun Dry run mode flag
+     * @return void
+     */
+    public function __construct(
+        ?string $filename = null,
+        ?string $type = 'objects',
+        ?string $parent = null,
+        ?bool $dryrun = false
+    ) {
+        $this->filename = $filename;
+        $this->type = $type;
+        $this->parent = $parent;
+        $this->dryrun = $dryrun;
+        $this->processed = 0;
+        $this->saved = 0;
+        $this->errors = 0;
+        $this->skipped = 0;
+        $this->errorsDetails = [];
+        /** @var \BEdita\Core\Model\Table\ObjectsTable $objectsTable */
+        $objectsTable = $this->fetchTable('objects');
+        $this->objectsTable = $objectsTable;
+        /** @var \BEdita\Core\Model\Table\ObjectsTable $typesTable */
+        $typesTable = $this->fetchTable($this->type);
+        $this->typeTable = $typesTable;
+        /** @var \BEdita\Core\Model\Table\TranslationsTable $translationsTable */
+        $translationsTable = $this->fetchTable('translations');
+        $this->translationsTable = $translationsTable;
+    }
+
+    /**
+     * Save objects
+     *
+     * @return void
+     */
+    public function objects(): void
+    {
+        foreach ($this->readCsv($this->filename) as $obj) {
+            try {
+                $this->object($obj);
+            } catch (\Exception $e) {
+                $this->errorsDetails[] = $e->getMessage();
+                $this->errors++;
+            } finally {
+                $this->processed++;
+            }
+        }
+    }
+
+    /**
+     * Save object
+     *
+     * @param array $obj Object data
+     * @return \BEdita\Core\Model\Entity\ObjectEntity
+     */
+    public function object(array $obj): ObjectEntity
+    {
+        $entity = $this->typeTable->newEmptyEntity();
+        if (!empty($obj['uname'])) {
+            $uname = $obj['uname'];
+            if ($this->objectsTable->exists(compact('uname'))) {
+                /** @var \BEdita\Core\Model\Entity\ObjectEntity $o */
+                $o = $this->objectsTable->find()->where(compact('uname'))->firstOrFail();
+                if ($o->type !== $this->type) {
+                    throw new BadRequestException(
+                        sprintf('Object uname "%s" already present with another type "%s"', $uname, $o->type)
+                    );
+                }
+                $entity = $this->typeTable->get($this->typeTable->getId($uname));
+            }
+        }
+        $entity = $this->typeTable->patchEntity($entity, $obj);
+        $entity->set('type', $this->type);
+        if ($this->dryrun === true) {
+            $this->skipped++;
+
+            return $entity;
+        }
+        $this->typeTable->saveOrFail($entity);
+        if (!empty($this->parent)) {
+            $this->setParent($entity, $this->parent);
+        }
+        $this->saved++;
+
+        return $entity;
+    }
+
+    /**
+     * Save translations
+     *
+     * @return void
+     */
+    public function translations(): void
+    {
+        foreach ($this->readCsv($this->filename) as $translation) {
+            try {
+                $this->translation($translation);
+            } catch (\Exception $e) {
+                $this->errorsDetails[] = $e->getMessage();
+                $this->errors++;
+            } finally {
+                $this->processed++;
+            }
+        }
+    }
+
+    /**
+     * Save translation
+     *
+     * @param array $data Translation data
+     * @return \BEdita\Core\Model\Entity\Translation
+     * @throws \Cake\Http\Exception\BadRequestException
+     */
+    public function translation(array $data): Translation
+    {
+        $uname = (string)Hash::get($data, 'object_uname');
+        if (!$this->objectsTable->exists(compact('uname'))) {
+            throw new BadRequestException(sprintf('Object "%s" not found', $uname));
+        }
+        /** @var \BEdita\Core\Model\Entity\ObjectEntity $o */
+        $o = $this->objectsTable->find()->where(compact('uname'))->firstOrFail();
+        $objectId = $o->id;
+        /** @var \BEdita\Core\Model\Entity\Translation $entity */
+        $entity = $this->translationsTable->find()
+            ->where([
+                'object_id' => $objectId,
+                'lang' => $data['lang'],
+            ])
+            ->first();
+        $translation = [
+            'object_id' => $objectId,
+        ];
+        if ($entity != null) {
+            $entity = $this->translationsTable->patchEntity($entity, $translation);
+        } else {
+            $entity = $this->translationsTable->newEntity($translation);
+        }
+        $entity->set('translated_fields', $this->translatedFields($data));
+        $entity->set('status', $this->getConfig('defaults')['status']);
+        $entity->set('lang', $data['lang']);
+        if (!empty($data['id'])) {
+            $entity->set('id', $data['id']);
+        }
+        if ($this->dryrun === true) {
+            $this->skipped++;
+
+            return $entity;
+        }
+        $this->translationsTable->saveOrFail($entity);
+        $this->saved++;
+
+        return $entity;
+    }
+
+    /**
+     * Get translated fields
+     *
+     * @param array $source Source data
+     * @return array
+     */
+    public function translatedFields(array $source): array
+    {
+        $fields = (string)Hash::get($source, 'translated_fields');
+        if (!empty($fields)) {
+            $fields = empty($fields) ? [] : json_decode($fields, true);
+
+            return $fields;
+        }
+        $fields = [];
+        foreach ($source as $key => $value) {
+            if (in_array($key, ['id', 'object_uname', 'lang'])) {
+                continue;
+            }
+            $subkey = strpos($key, 'translation_') === 0 ? substr($key, 12) : $key;
+            $fields[$subkey] = $value;
+        }
+
+        return $fields;
+    }
+}

--- a/src/Utility/Import.php
+++ b/src/Utility/Import.php
@@ -167,11 +167,11 @@ class Import
      *
      * @return void
      */
-    public function objects(): void
+    public function saveObjects(): void
     {
         foreach ($this->readCsv($this->filename) as $obj) {
             try {
-                $this->object($obj);
+                $this->saveObject($obj);
             } catch (\Exception $e) {
                 $this->errorsDetails[] = $e->getMessage();
                 $this->errors++;
@@ -187,7 +187,7 @@ class Import
      * @param array $obj Object data
      * @return \BEdita\Core\Model\Entity\ObjectEntity
      */
-    public function object(array $obj): ObjectEntity
+    public function saveObject(array $obj): ObjectEntity
     {
         $entity = $this->typeTable->newEmptyEntity();
         if (!empty($obj['uname'])) {
@@ -224,11 +224,11 @@ class Import
      *
      * @return void
      */
-    public function translations(): void
+    public function saveTranslations(): void
     {
         foreach ($this->readCsv($this->filename) as $translation) {
             try {
-                $this->translation($translation);
+                $this->saveTranslation($translation);
             } catch (\Exception $e) {
                 $this->errorsDetails[] = $e->getMessage();
                 $this->errors++;
@@ -245,7 +245,7 @@ class Import
      * @return \BEdita\Core\Model\Entity\Translation
      * @throws \Cake\Http\Exception\BadRequestException
      */
-    public function translation(array $data): Translation
+    public function saveTranslation(array $data): Translation
     {
         $uname = (string)Hash::get($data, 'object_uname');
         if (!$this->objectsTable->exists(compact('uname'))) {

--- a/src/Utility/TreeTrait.php
+++ b/src/Utility/TreeTrait.php
@@ -34,7 +34,8 @@ trait TreeTrait
     {
         /** @var \BEdita\Core\Model\Table\FoldersTable $foldersTable */
         $foldersTable = $this->fetchTable('Folders');
-        $parentEntity = $foldersTable->getId($folder);
+        $parentId = $foldersTable->getId($folder);
+        $parentEntity = $foldersTable->get($parentId);
         $association = $entity->getTable()->associations()->getByProperty('parents');
         $action = new SetRelatedObjectsAction(compact('association'));
         $relatedEntities = [$parentEntity];

--- a/src/Utility/TreeTrait.php
+++ b/src/Utility/TreeTrait.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\ImportTools\Utility;
+
+use BEdita\Core\Model\Action\SetRelatedObjectsAction;
+use BEdita\Core\Model\Entity\ObjectEntity;
+
+/**
+ * Trait for share Tree stuff.
+ */
+trait TreeTrait
+{
+    /**
+     * Set parent folder
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectEntity $entity Entity
+     * @param string $folder Folder uname or ID
+     * @return void
+     */
+    protected function setParent(ObjectEntity $entity, string $folder): void
+    {
+        $parentEntity = $this->fetchTable('Folders')->find('unameId', [$folder])->firstOrFail();
+        $association = $entity->getTable()->associations()->getByProperty('parents');
+        $action = new SetRelatedObjectsAction(compact('association'));
+        $relatedEntities = [$parentEntity];
+        $action(compact('entity', 'relatedEntities'));
+    }
+}

--- a/src/Utility/TreeTrait.php
+++ b/src/Utility/TreeTrait.php
@@ -32,7 +32,9 @@ trait TreeTrait
      */
     protected function setParent(ObjectEntity $entity, string $folder): void
     {
-        $parentEntity = $this->fetchTable('Folders')->find('unameId', [$folder])->firstOrFail();
+        /** @var \BEdita\Core\Model\Table\FoldersTable $foldersTable */
+        $foldersTable = $this->fetchTable('Folders');
+        $parentEntity = $foldersTable->getId($folder);
         $association = $entity->getTable()->associations()->getByProperty('parents');
         $action = new SetRelatedObjectsAction(compact('association'));
         $relatedEntities = [$parentEntity];

--- a/tests/TestApp/Application.php
+++ b/tests/TestApp/Application.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\ImportTools\Test\TestApp;
+
+use Cake\Http\BaseApplication;
+use Cake\Http\MiddlewareQueue;
+use Cake\Routing\Middleware\RoutingMiddleware;
+
+/**
+ * Application setup class.
+ *
+ * This defines the bootstrapping logic and middleware layers you
+ * want to use in your application.
+ */
+class Application extends BaseApplication
+{
+    /**
+     * @inheritDoc
+     */
+    public function bootstrap(): void
+    {
+        $this->addPlugin('BEdita/Core');
+        $this->addPlugin('BEdita/API');
+        $this->addPlugin('BEdita/ImportTools');
+    }
+
+    /**
+     * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to set in your App Class
+     * @return \Cake\Http\MiddlewareQueue
+     */
+    public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+    {
+        return $middlewareQueue->add(new RoutingMiddleware($this));
+    }
+}

--- a/tests/TestCase/Command/ImportCommandTest.php
+++ b/tests/TestCase/Command/ImportCommandTest.php
@@ -103,4 +103,16 @@ class ImportCommandTest extends TestCase
         $this->assertOutputContains('Processed: 3, Saved: 0, Skipped: 3, Errors: 0');
         $this->assertOutputContains('Done, bye!');
     }
+
+    /**
+     * Test execute method with parent option
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecuteOnMissingFile(): void
+    {
+        $this->exec('import -f missing.csv -t documents --dryrun 1');
+        $this->assertOutputContains('Bad csv source file name "missing.csv"');
+    }
 }

--- a/tests/TestCase/Command/ImportCommandTest.php
+++ b/tests/TestCase/Command/ImportCommandTest.php
@@ -98,8 +98,8 @@ class ImportCommandTest extends TestCase
         $this->assertOutputContains('File:');
         $this->assertOutputContains('articles1.csv');
         $this->assertOutputContains('Type: documents');
-        $this->assertOutputContains('Parent: none');
-        $this->assertOutputContains('Dry run mode: yes');
+        $this->assertOutputContains('Parent:');
+        $this->assertOutputContains('Dry run mode:');
         $this->assertOutputContains('Processed: 3, Saved: 0, Skipped: 3, Errors: 0');
         $this->assertOutputContains('Done, bye!');
     }

--- a/tests/TestCase/Command/ImportCommandTest.php
+++ b/tests/TestCase/Command/ImportCommandTest.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\ImportTools\Test\TestCase\Command;
+
+use BEdita\ImportTools\Command\ImportCommand;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\ImportTools\Command\ImportCommand} Test Case
+ *
+ * @coversDefaultClass \BEdita\ImportTools\Command\ImportCommand
+ */
+class ImportCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.Trees',
+    ];
+
+    /**
+     * The command used in test
+     *
+     * @var \BEdita\ImportTools\Command\ImportCommand
+     */
+    protected $command = null;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+        $this->command = new ImportCommand();
+    }
+
+    /**
+     * Test buildOptionParser method
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     */
+    public function testBuildOptionParser(): void
+    {
+        $this->exec('import --help');
+        $this->assertOutputContains('cake import [options]');
+        $this->assertOutputContains('--dryrun, -d');
+        $this->assertOutputContains('dry run mode');
+        $this->assertOutputContains('--file, -f');
+        $this->assertOutputContains('CSV file to import <comment>(required)</comment>');
+        $this->assertOutputContains('--help, -h');
+        $this->assertOutputContains('Display this help.');
+        $this->assertOutputContains('--parent, -p');
+        $this->assertOutputContains('destination folder uname');
+        $this->assertOutputContains('--quiet, -q');
+        $this->assertOutputContains('Enable quiet output.');
+        $this->assertOutputContains('--type, -t');
+        $this->assertOutputContains('entity type to import <comment>(required)</comment>');
+        $this->assertOutputContains('--verbose, -v');
+        $this->assertOutputContains('Enable verbose output.');
+    }
+
+    /**
+     * Test execute method
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecute(): void
+    {
+        $filename = TEST_FILES . DS . 'articles1.csv';
+        $this->exec(sprintf('import -f %s -t documents --dryrun 1', $filename));
+        $this->assertOutputContains('Start');
+        $this->assertOutputContains('File:');
+        $this->assertOutputContains('articles1.csv');
+        $this->assertOutputContains('Type: documents');
+        $this->assertOutputContains('Parent: none');
+        $this->assertOutputContains('Dry run mode: yes');
+        $this->assertOutputContains('Processed: 3, Saved: 0, Skipped: 3, Errors: 0');
+        $this->assertOutputContains('Done, bye!');
+    }
+}

--- a/tests/TestCase/Utility/ImportTest.php
+++ b/tests/TestCase/Utility/ImportTest.php
@@ -391,6 +391,7 @@ class ImportTest extends TestCase
         $uname = (string)Hash::get($data, 'object_uname');
         $objectsTable = $this->fetchTable('objects');
         if (!$objectsTable->exists(compact('uname'))) {
+            /** @var \BEdita\Core\Model\Entity\ObjectEntity $doc */
             $doc = $objectsTable->newEntity(['uname' => $uname, 'status' => 'on']);
             $doc->type = 'documents';
             $objectsTable->save($doc);

--- a/tests/TestCase/Utility/ImportTest.php
+++ b/tests/TestCase/Utility/ImportTest.php
@@ -72,11 +72,11 @@ class ImportTest extends TestCase
     }
 
     /**
-     * Data provider for objects test case.
+     * Data provider for save objects test case.
      *
      * @return array
      */
-    public function objectsProvider(): array
+    public function saveObjectsProvider(): array
     {
         return [
             'wrong type' => [
@@ -131,7 +131,7 @@ class ImportTest extends TestCase
     }
 
     /**
-     * Test `objects` method
+     * Test `saveObjects` method
      *
      * @param string $filename Filename
      * @param string $type Type
@@ -139,24 +139,24 @@ class ImportTest extends TestCase
      * @param bool $dryrun Dry run
      * @param array $expected Expected
      * @return void
-     * @dataProvider objectsProvider
-     * @covers ::objects()
+     * @dataProvider saveObjectsProvider
+     * @covers ::saveObjects()
      */
-    public function testObjects(string $filename, string $type, string $parent, bool $dryrun, array $expected): void
+    public function testSaveObjects(string $filename, string $type, string $parent, bool $dryrun, array $expected): void
     {
         $import = new Import($filename, $type, $parent, $dryrun);
-        $import->objects();
+        $import->saveObjects();
         foreach ($expected as $key => $value) {
             static::assertEquals($value, $import->$key);
         }
     }
 
     /**
-     * Data provider for object test case.
+     * Data provider for save object test case.
      *
      * @return array
      */
-    public function objectProvider(): array
+    public function saveObjectProvider(): array
     {
         $data = [
             'title' => 'test title',
@@ -196,7 +196,7 @@ class ImportTest extends TestCase
     }
 
     /**
-     * Test `object` method
+     * Test `saveObject` method
      *
      * @param string $f The Filename
      * @param string $t The Type
@@ -205,10 +205,10 @@ class ImportTest extends TestCase
      * @param array $data Data
      * @param array $expected Expected
      * @return void
-     * @dataProvider objectProvider
-     * @covers ::object()
+     * @dataProvider saveObjectProvider
+     * @covers ::saveObject()
      */
-    public function testObject(string $f, string $t, string $p, bool $dr, array $data, array $expected): void
+    public function testSaveObject(string $f, string $t, string $p, bool $dr, array $data, array $expected): void
     {
         if ($p !== '') {
             /** @var \BEdita\Core\Model\Table\FoldersTable $foldersTable */
@@ -222,7 +222,7 @@ class ImportTest extends TestCase
             }
         }
         $import = new Import($f, $t, $p, $dr);
-        $actual = $import->object($data);
+        $actual = $import->saveObject($data);
         foreach ($expected as $key => $value) {
             static::assertEquals($value, $actual->$key);
         }
@@ -234,13 +234,13 @@ class ImportTest extends TestCase
     }
 
     /**
-     * Test `object` method when exists
+     * Test `saveObject` method when exists
      *
      * @return void
-     * @dataProvider objectProvider
-     * @covers ::object()
+     * @dataProvider saveObjectProvider
+     * @covers ::saveObject()
      */
-    public function testObjectWhenExists(): void
+    public function testSaveObjectWhenExists(): void
     {
         $import = new Import(TEST_FILES . DS . 'articles1.csv', 'documents', '', false);
         $data = [
@@ -257,7 +257,7 @@ class ImportTest extends TestCase
         $doc = $objectsTable->newEntity($data);
         $doc->type = 'documents';
         $objectsTable->save($doc);
-        $actual = $import->object($data);
+        $actual = $import->saveObject($data);
         foreach ($data as $key => $value) {
             static::assertEquals($value, $actual->$key);
         }
@@ -265,13 +265,13 @@ class ImportTest extends TestCase
     }
 
     /**
-     * Test `object` method when exists
+     * Test `saveObject` method when exists
      *
      * @return void
-     * @dataProvider objectProvider
-     * @covers ::object()
+     * @dataProvider saveObjectProvider
+     * @covers ::saveObject()
      */
-    public function testObjectWhenExistsWrongType(): void
+    public function testSaveObjectWhenExistsWrongType(): void
     {
         $exception = new BadRequestException(
             sprintf('Object uname "%s" already present with another type "%s"', 'test-uname', 'events')
@@ -293,17 +293,17 @@ class ImportTest extends TestCase
         $doc->type = 'events';
         $objectsTable->save($doc);
         /** @var \BEdita\ImportTools\Utility\Import $actual */
-        $actual = $import->object($data);
+        $actual = $import->saveObject($data);
         static::assertEquals(0, $actual->saved);
         static::assertEquals(0, $actual->errors);
     }
 
     /**
-     * Data provider for translations with error test case.
+     * Data provider for save translations with error test case.
      *
      * @return array
      */
-    public function translationsWithErrorProvider(): array
+    public function saveTranslationsWithErrorProvider(): array
     {
         $filename = TEST_FILES . DS . 'translations1.csv';
         $type = 'translations';
@@ -356,7 +356,7 @@ class ImportTest extends TestCase
     }
 
     /**
-     * Test `translations` method on error
+     * Test `saveTranslations` method on error
      *
      * @param string $f Filename
      * @param string $t Type
@@ -364,24 +364,24 @@ class ImportTest extends TestCase
      * @param bool $dr Dry run
      * @param array $exp Expected
      * @return void
-     * @dataProvider translationsWithErrorProvider
-     * @covers ::translations()
+     * @dataProvider saveTranslationsWithErrorProvider
+     * @covers ::saveTranslations()
      */
-    public function testTranslationsWithError(string $f, string $t, string $p, bool $dr, array $exp): void
+    public function testSaveTranslationsWithError(string $f, string $t, string $p, bool $dr, array $exp): void
     {
         $import = new Import($f, $t, $p, $dr);
-        $import->translations();
+        $import->saveTranslations();
         foreach ($exp as $key => $value) {
             static::assertEquals($value, $import->$key);
         }
     }
 
     /**
-     * Data provider for translations test case.
+     * Data provider for save translations test case.
      *
      * @return array
      */
-    public function translationsProvider(): array
+    public function saveTranslationsProvider(): array
     {
         return [
             'import articles and translations with dry run true' => [
@@ -420,33 +420,33 @@ class ImportTest extends TestCase
     }
 
     /**
-     * Test `translations` method
+     * Test `saveTranslations` method
      *
      * @param string $arf Articles filename
      * @param string $trf Translations filename
      * @param bool $trdr Translations dry run
      * @param array $exp Expected
      * @return void
-     * @dataProvider translationsProvider
-     * @covers ::translations()
+     * @dataProvider saveTranslationsProvider
+     * @covers ::saveTranslations()
      */
-    public function testTranslations(string $arf, string $trf, bool $trdr, array $exp): void
+    public function testSaveTranslations(string $arf, string $trf, bool $trdr, array $exp): void
     {
         $import = new Import($arf, 'documents', '', false);
-        $import->objects();
+        $import->saveObjects();
         $import = new Import($trf, 'translations', '', $trdr);
-        $import->translations();
+        $import->saveTranslations();
         foreach ($exp as $key => $value) {
             static::assertEquals($value, $import->$key);
         }
     }
 
     /**
-     * Data provider for translation test case.
+     * Data provider for save translation test case.
      *
      * @return array
      */
-    public function translationProvider(): array
+    public function saveTranslationProvider(): array
     {
         $data = [
             'translation_title' => 'titolo test',
@@ -473,14 +473,14 @@ class ImportTest extends TestCase
     }
 
     /**
-     * Test `translation` method
+     * Test `saveTranslation` method
      *
      * @return void
-     * @dataProvider translationProvider
-     * @covers ::translation()
+     * @dataProvider saveTranslationProvider
+     * @covers ::saveTranslation()
      * @covers ::translatedFields()
      */
-    public function testTranslation(string $f, bool $dr, array $data, array $expected): void
+    public function testSaveTranslation(string $f, bool $dr, array $data, array $expected): void
     {
         $uname = (string)Hash::get($data, 'object_uname');
         $objectsTable = $this->fetchTable('objects');
@@ -491,7 +491,7 @@ class ImportTest extends TestCase
             $objectsTable->save($doc);
         }
         $import = new Import($f, 'translations', '', $dr);
-        $actual = $import->translation($data);
+        $actual = $import->saveTranslation($data);
         foreach ($expected as $key => $value) {
             if (in_array($key, ['id', 'object_uname', 'lang'])) {
                 continue;

--- a/tests/TestCase/Utility/ImportTest.php
+++ b/tests/TestCase/Utility/ImportTest.php
@@ -292,6 +292,7 @@ class ImportTest extends TestCase
         $doc = $objectsTable->newEntity($data);
         $doc->type = 'events';
         $objectsTable->save($doc);
+        /** @var \BEdita\ImportTools\Utility\Import $actual */
         $actual = $import->object($data);
         static::assertEquals(0, $actual->saved);
         static::assertEquals(0, $actual->errors);

--- a/tests/TestCase/Utility/ImportTest.php
+++ b/tests/TestCase/Utility/ImportTest.php
@@ -1,0 +1,460 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\ImportTools\Test\TestCase\Utility;
+
+use BEdita\Core\Utility\LoggedUser;
+use BEdita\ImportTools\Utility\Import;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
+
+/**
+ * {@see \BEdita\ImportTools\Utility\Import} Test Case
+ *
+ * @covers \BEdita\ImportTools\Utility\Import
+ */
+class ImportTest extends TestCase
+{
+    use LocatorAwareTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.Trees',
+    ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        LoggedUser::setUserAdmin();
+    }
+
+    /**
+     * Test constructor
+     *
+     * @return void
+     * @covers ::__construct()
+     */
+    public function testConstructor(): void
+    {
+        $filename = 'articles1.csv';
+        $type = 'documents';
+        $parent = null;
+        $dryrun = true;
+        $import = new Import($filename, $type, $parent, $dryrun);
+        static::assertEquals($filename, $import->filename);
+        static::assertEquals($type, $import->type);
+        static::assertEquals($parent, $import->parent);
+        static::assertEquals($dryrun, $import->dryrun);
+        static::assertEquals(0, $import->processed);
+        static::assertEquals(0, $import->saved);
+        static::assertEquals(0, $import->errors);
+        static::assertEquals(0, $import->skipped);
+    }
+
+    /**
+     * Data provider for objects test case.
+     *
+     * @return array
+     */
+    public function objectsProvider(): array
+    {
+        $filename = TEST_FILES . DS . 'articles1.csv';
+        $type = 'documents';
+        $parent = '';
+
+        return [
+            'process objects with dry run true' => [
+                $filename,
+                $type,
+                $parent,
+                true,
+                [
+                    'filename' => $filename,
+                    'type' => $type,
+                    'parent' => $parent,
+                    'dryrun' => true,
+                    'processed' => 3,
+                    'saved' => 0,
+                    'errors' => 0,
+                    'skipped' => 3,
+                ],
+            ],
+            'process objects with dry run false' => [
+                $filename,
+                $type,
+                $parent,
+                false,
+                [
+                    'filename' => $filename,
+                    'type' => $type,
+                    'parent' => $parent,
+                    'dryrun' => false,
+                    'processed' => 3,
+                    'saved' => 3,
+                    'errors' => 0,
+                    'skipped' => 0,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `objects` method
+     *
+     * @param string $filename Filename
+     * @param string $type Type
+     * @param string $parent Parent
+     * @param bool $dryrun Dry run
+     * @param array $expected Expected
+     * @return void
+     * @dataProvider objectsProvider
+     * @covers ::objects()
+     */
+    public function testObjects(string $filename, string $type, string $parent, bool $dryrun, array $expected): void
+    {
+        $import = new Import($filename, $type, $parent, $dryrun);
+        $import->objects();
+        foreach ($expected as $key => $value) {
+            static::assertEquals($value, $import->$key);
+        }
+    }
+
+    /**
+     * Data provider for object test case.
+     *
+     * @return array
+     */
+    public function objectProvider(): array
+    {
+        $filename = TEST_FILES . DS . 'articles1.csv';
+        $type = 'documents';
+        $parent = '';
+        $data = [
+            'title' => 'test title',
+            'description' => 'test description',
+            'body' => 'test body',
+            'status' => 'on',
+            'uname' => 'test-uname',
+            'lang' => 'en',
+        ];
+
+        return [
+            'process object with dry run true' => [
+                $filename,
+                $type,
+                $parent,
+                true,
+                $data,
+                $data,
+            ],
+            'process object with dry run false' => [
+                $filename,
+                $type,
+                $parent,
+                false,
+                $data,
+                $data,
+            ],
+        ];
+    }
+
+    /**
+     * Test `object` method
+     *
+     * @param string $filename Filename
+     * @param string $type Type
+     * @param string $parent Parent
+     * @param bool $dryrun Dry run
+     * @param array $data Data
+     * @param array $expected Expected
+     * @return void
+     * @dataProvider objectProvider
+     * @covers ::object()
+     */
+    public function testObject(string $filename, string $type, string $parent, bool $dryrun, array $data, array $expected): void
+    {
+        $import = new Import($filename, $type, $parent, $dryrun);
+        $actual = $import->object($data);
+        foreach ($expected as $key => $value) {
+            static::assertEquals($value, $actual->$key);
+        }
+        if ($dryrun === true) {
+            static::assertEquals(1, $import->skipped);
+        } else {
+            static::assertEquals(1, $import->saved);
+        }
+    }
+
+    /**
+     * Data provider for translations with error test case.
+     *
+     * @return array
+     */
+    public function translationsWithErrorProvider(): array
+    {
+        $filename = TEST_FILES . DS . 'translations1.csv';
+        $type = 'translations';
+        $parent = '';
+
+        return [
+            'process translations with dry run true with 404 errors' => [
+                $filename,
+                $type,
+                $parent,
+                true,
+                [
+                    'filename' => $filename,
+                    'type' => $type,
+                    'parent' => $parent,
+                    'dryrun' => true,
+                    'processed' => 3,
+                    'saved' => 0,
+                    'errors' => 3,
+                    'skipped' => 0,
+                    'errorsDetails' => [
+                        'Object "dummy-article-1" not found',
+                        'Object "dummy-article-2" not found',
+                        'Object "dummy-article-3" not found',
+                    ],
+                ],
+            ],
+            'process translations with dry run false with 404 errors' => [
+                $filename,
+                $type,
+                $parent,
+                false,
+                [
+                    'filename' => $filename,
+                    'type' => $type,
+                    'parent' => $parent,
+                    'dryrun' => false,
+                    'processed' => 3,
+                    'saved' => 0,
+                    'errors' => 3,
+                    'skipped' => 0,
+                    'errorsDetails' => [
+                        'Object "dummy-article-1" not found',
+                        'Object "dummy-article-2" not found',
+                        'Object "dummy-article-3" not found',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `translations` method on error
+     *
+     * @param string $f Filename
+     * @param string $t Type
+     * @param string $p Parent
+     * @param bool $dr Dry run
+     * @param array $exp Expected
+     * @return void
+     * @dataProvider translationsWithErrorProvider
+     * @covers ::translations()
+     */
+    public function testTranslationsWithError(string $f, string $t, string $p, bool $dr, array $exp): void
+    {
+        $import = new Import($f, $t, $p, $dr);
+        $import->translations();
+        foreach ($exp as $key => $value) {
+            static::assertEquals($value, $import->$key);
+        }
+    }
+
+    /**
+     * Data provider for translations test case.
+     *
+     * @return array
+     */
+    public function translationsProvider(): array
+    {
+        return [
+            'import articles and translations with dry run true' => [
+                TEST_FILES . DS . 'articles1.csv',
+                TEST_FILES . DS . 'translations1.csv',
+                true,
+                [
+                    'filename' => TEST_FILES . DS . 'translations1.csv',
+                    'type' => 'translations',
+                    'parent' => '',
+                    'dryrun' => true,
+                    'processed' => 3,
+                    'saved' => 0,
+                    'errors' => 0,
+                    'skipped' => 3,
+                    'errorsDetails' => [],
+                ],
+            ],
+            'import articles and translations with dry run false' => [
+                TEST_FILES . DS . 'articles2.csv',
+                TEST_FILES . DS . 'translations2.csv',
+                false,
+                [
+                    'filename' => TEST_FILES . DS . 'translations2.csv',
+                    'type' => 'translations',
+                    'parent' => '',
+                    'dryrun' => false,
+                    'processed' => 3,
+                    'saved' => 3,
+                    'errors' => 0,
+                    'skipped' => 0,
+                    'errorsDetails' => [],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `translations` method
+     *
+     * @param string $arf Articles filename
+     * @param string $trf Translations filename
+     * @param bool $trdr Translations dry run
+     * @param array $exp Expected
+     * @return void
+     * @dataProvider translationsProvider
+     * @covers ::translations()
+     */
+    public function testTranslations(string $arf, string $trf, bool $trdr, array $exp): void
+    {
+        $import = new Import($arf, 'documents', '', false);
+        $import->objects();
+        $import = new Import($trf, 'translations', '', $trdr);
+        $import->translations();
+        foreach ($exp as $key => $value) {
+            static::assertEquals($value, $import->$key);
+        }
+    }
+
+    /**
+     * Data provider for translation test case.
+     *
+     * @return array
+     */
+    public function translationProvider(): array
+    {
+        $data = [
+            'translation_title' => 'titolo test',
+            'translation_description' => 'descrizione test',
+            'translation_body' => 'body test',
+            'object_uname' => 'some-new-article',
+            'lang' => 'it',
+        ];
+
+        return [
+            'process translation with dry run true' => [
+                TEST_FILES . DS . 'translations1.csv',
+                true,
+                $data,
+                $data,
+            ],
+            'process translation with dry run false' => [
+                TEST_FILES . DS . 'translations1.csv',
+                false,
+                $data,
+                $data,
+            ],
+        ];
+    }
+
+    /**
+     * Test `translation` method
+     *
+     * @return void
+     * @dataProvider translationProvider
+     * @covers ::translation()
+     * @covers ::translatedFields()
+     */
+    public function testTranslation(string $f, bool $dr, array $data, array $expected): void
+    {
+        $uname = (string)Hash::get($data, 'object_uname');
+        $objectsTable = $this->fetchTable('objects');
+        if (!$objectsTable->exists(compact('uname'))) {
+            $doc = $objectsTable->newEntity(['uname' => $uname, 'status' => 'on']);
+            $doc->type = 'documents';
+            $objectsTable->save($doc);
+        }
+        $import = new Import($f, 'translations', '', $dr);
+        $actual = $import->translation($data);
+        foreach ($expected as $key => $value) {
+            if (in_array($key, ['id', 'object_uname', 'lang'])) {
+                continue;
+            }
+            $subkey = strpos($key, 'translation_') === 0 ? substr($key, 12) : $key;
+            static::assertEquals($value, $actual->translated_fields[$subkey]);
+        }
+        if ($dr === true) {
+            static::assertEquals(1, $import->skipped);
+        } else {
+            static::assertEquals(1, $import->saved);
+        }
+    }
+
+    public function translatedFieldsProvider(): array
+    {
+        return [
+            'translated fields by prefix translation_' => [
+                [
+                    'translation_title' => 'titolo test',
+                    'translation_description' => 'descrizione test',
+                    'translation_body' => 'body test',
+                    'object_uname' => 'some-new-article',
+                    'lang' => 'it',
+                ],
+                [
+                    'title' => 'titolo test',
+                    'description' => 'descrizione test',
+                    'body' => 'body test',
+                ],
+            ],
+            'translated fields by translated_fields' => [
+                [
+                    'translated_fields' => '{"title":"titolo test","description":"descrizione test","body":"body test"}',
+                    'object_uname' => 'some-new-article',
+                    'lang' => 'it',
+                    'id' => 1,
+                ],
+                [
+                    'title' => 'titolo test',
+                    'description' => 'descrizione test',
+                    'body' => 'body test',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `translatedFields` method
+     *
+     * @return void
+     * @dataProvider translatedFieldsProvider
+     * @covers ::translatedFields()
+     */
+    public function testTranslatedFields(array $data, array $expected): void
+    {
+        $import = new Import();
+        $actual = $import->translatedFields($data);
+        static::assertEquals($expected, $actual);
+    }
+}

--- a/tests/TestCase/Utility/TreeTraitTest.php
+++ b/tests/TestCase/Utility/TreeTraitTest.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\ImportTools\Test\TestCase\Utility;
+
+use BEdita\Core\Utility\LoggedUser;
+use BEdita\ImportTools\Utility\TreeTrait;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\ImportTools\Utility\TreeTrait} Test Case
+ *
+ * @covers \BEdita\ImportTools\Utility\TreeTrait
+ */
+class TreeTraitTest extends TestCase
+{
+    use LocatorAwareTrait;
+    use TreeTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Trees',
+        'plugin.BEdita/Core.Users',
+    ];
+
+    /**
+     * ObjectTypesTable instance
+     *
+     * @var \BEdita\Core\Model\Table\ObjectTypesTable
+     */
+    protected $ObjectTypes = null;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var \BEdita\Core\Model\Table\ObjectTypesTable $objectTypes */
+        $objectTypes = $this->fetchTable('ObjectTypes');
+        $this->ObjectTypes = $objectTypes;
+
+        LoggedUser::setUserAdmin();
+    }
+
+    public function tearDown(): void
+    {
+        $this->getTableLocator()->clear();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test `setParent` method
+     *
+     * @return void
+     * @covers ::setParent()
+     */
+    public function testSetParent(): void
+    {
+        $uname = 'import-tools-test-folder';
+        /** @var \BEdita\Core\Model\Table\FoldersTable $foldersTable */
+        $foldersTable = $this->fetchTable('Folders');
+        /** @var \BEdita\Core\Model\Entity\Folder $parent */
+        $parent = $foldersTable->newEntity(['uname' => $uname, 'status' => 'on']);
+        $parent = $foldersTable->save($parent);
+        /** @var \BEdita\Core\Model\Entity\Folder $parent */
+        $parent = $foldersTable->find()->where(['uname' => $uname])->contain('Children')->first();
+        $childrenCount = count($parent->children);
+
+        /** @var \BEdita\Core\Model\Table\ObjectsTable $objectsTable */
+        $objectsTable = $this->fetchTable('Objects');
+        /** @var \BEdita\Core\Model\Entity\ObjectEntity $child */
+        $child = $objectsTable->newEntity(['title' => 'test child', 'status' => 'on']);
+        $child->type = 'documents';
+        $child = $objectsTable->save($child);
+
+        // set parent
+        $this->setParent($child, $uname);
+
+        // verify that folder is parent for child
+        /** @var \BEdita\Core\Model\Entity\Folder $parent */
+        $parent = $foldersTable->find()->where(['uname' => $uname])->contain('Children')->first();
+        $this->assertSame($childrenCount + 1, count($parent->children));
+        $this->assertSame($child->id, $parent->children[0]->id);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,6 +23,18 @@ declare(strict_types=1);
 
 use BEdita\Core\Filesystem\Adapter\LocalAdapter;
 use BEdita\Core\Filesystem\FilesystemRegistry;
+use BEdita\Core\ORM\Locator\TableLocator;
+use BEdita\ImportTools\Test\TestApp\Application;
+use Cake\Cache\Cache;
+use Cake\Cache\Engine\ArrayEngine;
+use Cake\Cache\Engine\NullEngine;
+use Cake\Core\Configure;
+use Cake\Datasource\ConnectionManager;
+use Cake\Log\Engine\ConsoleLog;
+use Cake\Log\Log;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Security;
+use Migrations\TestSuite\Migrator;
 
 $findRoot = function ($root) {
     do {
@@ -32,16 +44,67 @@ $findRoot = function ($root) {
             return $root;
         }
     } while ($root !== $lastRoot);
-
     throw new Exception('Cannot find the root of the application, unable to run tests');
 };
 $root = $findRoot(__FILE__);
 unset($findRoot);
-
 chdir($root);
 
 require_once 'vendor/cakephp/cakephp/src/basics.php';
 require_once 'vendor/autoload.php';
+
+define('ROOT', $root . DS . 'tests' . DS);
+define('APP', ROOT . 'TestApp' . DS);
+define('TMP', sys_get_temp_dir() . DS);
+define('LOGS', ROOT . DS . 'logs' . DS);
+define('CONFIG', ROOT . DS . 'config' . DS);
+define('CACHE', TMP . 'cache' . DS);
+define('CORE_PATH', $root . DS . 'vendor' . DS . 'cakephp' . DS . 'cakephp' . DS);
+
+Configure::write('debug', true);
+Configure::write('App', [
+    'namespace' => 'BEdita\ImportTools\Test\TestApp',
+    'encoding' => 'UTF-8',
+    'paths' => [
+        'plugins' => [ROOT . 'Plugin' . DS],
+        'templates' => [APP . 'Template' . DS],
+    ],
+]);
+
+Log::setConfig([
+    'debug' => [
+        'engine' => ConsoleLog::class,
+        'levels' => ['notice', 'info', 'debug'],
+    ],
+    'error' => [
+        'engine' => ConsoleLog::class,
+        'levels' => ['warning', 'error', 'critical', 'alert', 'emergency'],
+    ],
+]);
+
+Cache::drop('_bedita_object_types_');
+Cache::drop('_bedita_core_');
+Cache::setConfig([
+    '_cake_core_' => ['engine' => ArrayEngine::class],
+    '_cake_model_' => ['engine' => ArrayEngine::class],
+    '_bedita_object_types_' => ['className' => NullEngine::class],
+    '_bedita_core_' => ['className' => NullEngine::class],
+]);
+
+ConnectionManager::drop('test');
+if (!getenv('db_dsn')) {
+    putenv('db_dsn=sqlite:///:memory:');
+}
+ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);
+ConnectionManager::alias('test', 'default');
+
+if (!TableRegistry::getTableLocator() instanceof TableLocator) {
+    TableRegistry::setTableLocator(new TableLocator());
+}
+
+Security::setSalt('wIYveuyasdNTn3ikclAP6msatcNj76a6iuOG');
+
+(new Migrator())->run(['plugin' => 'BEdita/Core']);
 
 const TEST_FILES = __DIR__ . DS . 'files';
 const WWW_ROOT = TEST_FILES; // Necessary to avoid warning when instantiating LocalAdapter.
@@ -50,3 +113,11 @@ FilesystemRegistry::setConfig('test-data', [
     'className' => LocalAdapter::class,
     'path' => TEST_FILES,
 ]);
+
+$app = new Application(dirname(__DIR__) . '/config');
+$app->bootstrap();
+$app->pluginBootstrap();
+
+// clear all before running tests
+TableRegistry::getTableLocator()->clear();
+Cache::clearAll();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,7 +34,6 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Log\Engine\ConsoleLog;
 use Cake\Log\Log;
 use Cake\ORM\TableRegistry;
-use Cake\Routing\Route\Route;
 use Cake\Routing\Router;
 use Cake\Utility\Security;
 use Migrations\TestSuite\Migrator;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,10 +29,13 @@ use Cake\Cache\Cache;
 use Cake\Cache\Engine\ArrayEngine;
 use Cake\Cache\Engine\NullEngine;
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Engine\ConsoleLog;
 use Cake\Log\Log;
 use Cake\ORM\TableRegistry;
+use Cake\Routing\Route\Route;
+use Cake\Routing\Router;
 use Cake\Utility\Security;
 use Migrations\TestSuite\Migrator;
 
@@ -117,6 +120,10 @@ FilesystemRegistry::setConfig('test-data', [
 $app = new Application(dirname(__DIR__) . '/config');
 $app->bootstrap();
 $app->pluginBootstrap();
+
+Router::reload();
+Router::fullBaseUrl('http://localhost');
+Plugin::getCollection()->add(new \BEdita\ImportTools\Plugin(['middleware' => true]));
 
 // clear all before running tests
 TableRegistry::getTableLocator()->clear();

--- a/tests/config/bootstrap.php
+++ b/tests/config/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+// Do nothing. :)

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -1,0 +1,3 @@
+<?php
+
+// Do nothing. :)

--- a/tests/files/articles1.csv
+++ b/tests/files/articles1.csv
@@ -1,0 +1,4 @@
+"uname","title","description","body"
+"dummy-article-1","My dummy article 1","My dummy article 1 description","My dummy article 1 body"
+"dummy-article-2","My dummy article 2","My dummy article 2 description","My dummy article 2 body"
+"dummy-article-3","My dummy article 3","My dummy article 3 description","My dummy article 3 body"

--- a/tests/files/articles2.csv
+++ b/tests/files/articles2.csv
@@ -1,0 +1,4 @@
+"uname","title","description","body"
+"dummy-article-1-bis","My dummy article 1-bis","My dummy article 1-bis description","My dummy article 1-bis body"
+"dummy-article-2-bis","My dummy article 2-bis","My dummy article 2-bis description","My dummy article 2-bis body"
+"dummy-article-3-bis","My dummy article 3-bis","My dummy article 3-bis description","My dummy article 3-bis body"

--- a/tests/files/translations1.csv
+++ b/tests/files/translations1.csv
@@ -1,0 +1,4 @@
+"lang","object_uname","translation_title","translation_description","translation_body"
+"it","dummy-article-1","Il mio articolo banale 1","Il mio articolo banale 1 description","Il mio articolo banale 1 body"
+"it","dummy-article-2","Il mio articolo banale 2","Il mio articolo banale 2 description","Il mio articolo banale 2 body"
+"it","dummy-article-3","Il mio articolo banale 3","Il mio articolo banale 3 description","Il mio articolo banale 3 body"

--- a/tests/files/translations2.csv
+++ b/tests/files/translations2.csv
@@ -1,0 +1,4 @@
+"lang","object_uname","translation_title","translation_description","translation_body"
+"it","dummy-article-1-bis","Il mio articolo banale 1 bis","Il mio articolo banale 1 bis descrizione","Il mio articolo banale 1 bis corpo del testo"
+"it","dummy-article-2-bis","Il mio articolo banale 2 bis","Il mio articolo banale 2 bis descrizione","Il mio articolo banale 2 bis corpo del testo"
+"it","dummy-article-3-bis","Il mio articolo banale 3 bis","Il mio articolo banale 3 bis descrizione","Il mio articolo banale 3 bis corpo del testo"


### PR DESCRIPTION
This provides an `ImportCommand` to import objects, translations and data on tree.

Usage:
```bash
// basic
$ bin/cake import --file documents.csv --type documents
$ bin/cake import -f documents.csv -t documents

// dry-run
$ bin/cake import --file articles.csv --type articles --dryrun yes
$ bin/cake import -f articles.csv -t articles -d yes

// destination folder
$ bin/cake import --file news.csv --type news --parent my-folder-uname
$ bin/cake import -f news.csv -t news -p my-folder-uname

// translations
$ bin/cake import --file translations.csv --type translations
$ bin/cake import -f translations.csv -t translations
```