### PR TITLE
bedita github-workflows v2 and php 8.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gh-actions:
+        patterns: ['actions/*']
+      docker:
+        patterns: ['docker/*']
+      codecov:
+        patterns: ['codecov/*']

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,12 +14,12 @@ on:
 
 jobs:
   cs:
-    uses: bedita/github-workflows/.github/workflows/php-cs.yml@v1
+    uses: bedita/github-workflows/.github/workflows/php-cs.yml@v2
     with:
       php_versions: '["7.4", "8.1", "8.2"]'
 
   stan:
-    uses: bedita/github-workflows/.github/workflows/php-stan.yml@v1
+    uses: bedita/github-workflows/.github/workflows/php-stan.yml@v2
     with:
       php_versions: '["7.4", "8.1", "8.2"]'
 
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [7.4, 8.1, 8.2]
+        php-version: [7.4, 8.1, 8.2, 8.3]
 
     steps:
       - name: 'Checkout current revision'
@@ -74,6 +74,7 @@ jobs:
       - name: 'Export coverage results'
         uses: 'codecov/codecov-action@v3'
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}s
           files: './clover.xml'
           env_vars: PHP_VERSION
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   release-job:
-    uses: bedita/github-workflows/.github/workflows/release.yml@v1
+    uses: bedita/github-workflows/.github/workflows/release.yml@v2
     with:
       main_branch: 'main'
       dist_branches: '["main"]'


### PR DESCRIPTION
This updates github workflows to use bedita github-workflows v2 and php 8.3.
Bonus: add dependabot config to open automatically PR on action/codecov/docker updates.