### PR TITLE
TranslateFile and TranslateObjects commands

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: 'Checkout current revision'
-        uses: 'actions/checkout@v3'
+        uses: 'actions/checkout@v4'
 
       - name: 'Composer config GH token if available'
         run: 'if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi'
@@ -51,7 +51,7 @@ jobs:
         run: echo "path=$(composer global config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: 'Share Composer cache across runs'
-        uses: 'actions/cache@v3'
+        uses: 'actions/cache@v4'
         with:
           path: '${{ steps.cachedir.outputs.path }}'
           key: "composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}"
@@ -62,24 +62,24 @@ jobs:
         run: 'composer install --prefer-dist --no-interaction'
 
       - name: 'Run PHPUnit with coverage'
-        run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
+        run: 'vendor/bin/phpunit --coverage-clover=${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.php-version }}-clover.xml'
 
       - name: Check test coverage
         id: test-coverage
         uses: johanvanhelden/gha-clover-test-coverage-check@v1
         with:
           percentage: '80'
-          filename: 'clover.xml'
+          filename: '${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.php-version }}-clover.xml'
 
       - name: 'Export coverage results'
         uses: 'codecov/codecov-action@v3'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}s
-          files: './clover.xml'
+          files: './${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.php-version }}-clover.xml'
           env_vars: PHP_VERSION
 
       - name: 'Archive code coverage results'
-        uses: 'actions/upload-artifact@v3'
+        uses: 'actions/upload-artifact@v4'
         with:
           name: 'PHP ${{ matrix.php }}'
-          path: 'clover.xml'
+          path: '${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.php-version }}-clover.xml'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -62,24 +62,24 @@ jobs:
         run: 'composer install --prefer-dist --no-interaction'
 
       - name: 'Run PHPUnit with coverage'
-        run: 'vendor/bin/phpunit --coverage-clover=${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.php-version }}-clover.xml'
+        run: 'vendor/bin/phpunit --coverage-clover=${{ matrix.php-version }}-${{ strategy.job-index }}-clover.xml'
 
       - name: Check test coverage
         id: test-coverage
         uses: johanvanhelden/gha-clover-test-coverage-check@v1
         with:
           percentage: '80'
-          filename: '${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.php-version }}-clover.xml'
+          filename: '${{ matrix.php-version }}-${{ strategy.job-index }}-clover.xml'
 
       - name: 'Export coverage results'
         uses: 'codecov/codecov-action@v3'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}s
-          files: './${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.php-version }}-clover.xml'
+          files: './${{ matrix.php-version }}-${{ strategy.job-index }}-clover.xml'
           env_vars: PHP_VERSION
 
       - name: 'Archive code coverage results'
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@v3'
         with:
           name: 'PHP ${{ matrix.php }}'
-          path: '${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.php-version }}-clover.xml'
+          path: '${{ matrix.php-version }}-${{ strategy.job-index }}-clover.xml'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -68,7 +68,7 @@ jobs:
         id: test-coverage
         uses: johanvanhelden/gha-clover-test-coverage-check@v1
         with:
-          percentage: '85'
+          percentage: '80'
           filename: "${{ matrix.php-version }}-${{ strategy.job-index }}-clover.xml"
 
       - name: 'Export coverage results'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,12 +16,12 @@ jobs:
   cs:
     uses: bedita/github-workflows/.github/workflows/php-cs.yml@v2
     with:
-      php_versions: '["7.4", "8.1", "8.2"]'
+      php_versions: '["7.4", "8.1", "8.2", "8.3"]'
 
   stan:
     uses: bedita/github-workflows/.github/workflows/php-stan.yml@v2
     with:
-      php_versions: '["7.4", "8.1", "8.2"]'
+      php_versions: '["7.4", "8.1", "8.2", "8.3"]'
 
   unit:
     name: 'Run unit tests'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -68,7 +68,7 @@ jobs:
         id: test-coverage
         uses: johanvanhelden/gha-clover-test-coverage-check@v1
         with:
-          percentage: '85'
+          percentage: '80'
           filename: 'clover.xml'
 
       - name: 'Export coverage results'

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,9 @@
         "cakephp/cakephp": "^4.4"
     },
     "require-dev": {
-        "bedita/core": "^5.21",
         "bedita/api": "^5.21",
+        "bedita/core": "^5.21",
+        "bedita/i18n": "^4.4",
         "cakephp/cakephp-codesniffer": "~4.5",
         "phpstan/phpstan": "^1.8",
         "phpstan/extension-installer": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "cakephp/cakephp": "^4.4"
     },
     "require-dev": {
-        "bedita/core": "^5.14",
-        "bedita/api": "^5.14",
+        "bedita/core": "^5.21",
+        "bedita/api": "^5.21",
         "cakephp/cakephp-codesniffer": "~4.5",
         "phpstan/phpstan": "^1.8",
         "phpstan/extension-installer": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
     ],
     "require": {
         "php": ">= 7.4",
-        "cakephp/cakephp": "^4.4"
+        "cakephp/cakephp": "^4.4",
+        "bedita/api": "^5.22",
+        "bedita/core": "^5.22",
+        "bedita/i18n": "^4.4"
     },
     "require-dev": {
-        "bedita/api": "^5.21",
-        "bedita/core": "^5.21",
-        "bedita/i18n": "^4.4",
         "cakephp/cakephp-codesniffer": "~4.5",
         "phpstan/phpstan": "^1.8",
         "phpstan/extension-installer": "^1.0",

--- a/src/Command/TranslateFileCommand.php
+++ b/src/Command/TranslateFileCommand.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\ImportTools\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Core\Configure;
+
+/**
+ * TranslateFile command.
+ * Perform from a file using a translator engine.
+ * The input file is translated from a source language to a destination language using a translator engine.
+ * The output file is created with the translated content.
+ * The translator engine is defined in the configuration.
+ * The configuration must contain the translator engine class and options
+ * I.e.:
+ * 'Translators' => [
+ *   'deepl' => [
+ *      'name' => 'DeepL',
+ *      'class' => '\BEdita\I18n\Deepl\Core\Translator',
+ *      'options' => [
+ *        'auth_key' => '************',
+ *      ],
+ *   ],
+ * ],
+ */
+class TranslateFileCommand extends Command
+{
+    /**
+     * @inheritDoc
+     */
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        $parser->addOption('input', [
+            'short' => 'i',
+            'help' => 'Input file path',
+            'required' => true,
+        ]);
+        $parser->addOption('output', [
+            'short' => 'o',
+            'help' => 'Output file path',
+            'required' => true,
+        ]);
+        $parser->addOption('from', [
+            'short' => 'f',
+            'help' => 'Source language',
+            'required' => true,
+        ]);
+        $parser->addOption('to', [
+            'short' => 't',
+            'help' => 'Dest language',
+            'required' => true,
+        ]);
+        $parser->addOption('translator', [
+            'short' => 'e',
+            'help' => 'Translator engine name',
+            'required' => true,
+        ]);
+
+        return $parser;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io): int
+    {
+        $i = (string)($args->getOption('input') ?? (string)$args->getOption('i'));
+        if (!file_exists($i)) {
+            $io->err(sprintf('Input file "%s" does not exist', $i));
+
+            return self::CODE_ERROR;
+        }
+        $o = (string)($args->getOption('output') ?? $args->getOption('o'));
+        $f = (string)($args->getOption('from') ?? $args->getOption('f'));
+        $t = (string)($args->getOption('to') ?? $args->getOption('t'));
+        $e = (string)($args->getOption('translator') ?? $args->getOption('e'));
+        $io->out(sprintf('"%s" [%s] -> "%s" [%s] using "%s" engine.', $i, $f, $o, $t, $e));
+        $cfg = (array)Configure::read(sprintf('Translators.%s', $e));
+        if (empty($cfg)) {
+            $io->err(sprintf('No translator engine "%s" is set in configuration', $e));
+
+            return self::CODE_ERROR;
+        }
+        $class = $cfg['class'];
+        $options = $cfg['options'];
+        $translator = new $class();
+        $translator->setup($options);
+        $translation = $translator->translate([(string)file_get_contents($i)], $f, $t);
+        $translation = json_decode($translation, true);
+        $translation = $translation['translation'];
+        file_put_contents($o, $translation);
+        $io->out('Done. Bye!');
+
+        return self::CODE_SUCCESS;
+    }
+}

--- a/src/Command/TranslateObjectsCommand.php
+++ b/src/Command/TranslateObjectsCommand.php
@@ -249,7 +249,6 @@ class TranslateObjectsCommand extends Command
             if ($this->limit !== null && ($this->ok + $this->error >= $this->limit)) {
                 break;
             }
-            $object = $this->fetchTable($object->type)->find()->where(['id' => $object->id])->firstOrFail();
             $this->processObject($object, $from, $to);
         }
     }
@@ -329,6 +328,7 @@ class TranslateObjectsCommand extends Command
      */
     public function translate($object, $from, $to): void
     {
+        $object = $this->fetchTable($object->type)->find()->where(['id' => $object->id])->firstOrFail();
         $translatableFields = $this->translatableFields($object->type);
         if (empty($translatableFields)) {
             return;

--- a/src/Command/TranslateObjectsCommand.php
+++ b/src/Command/TranslateObjectsCommand.php
@@ -1,0 +1,258 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\ImportTools\Command;
+
+use BEdita\Core\Utility\LoggedUser;
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Core\Configure;
+use Cake\Core\InstanceConfigTrait;
+use Cake\Database\Expression\QueryExpression;
+use Cake\Utility\Hash;
+
+/**
+ * TranslateObjects command.
+ * Translate objects from a language to another using a translator engine.
+ * The translator engine is defined in the configuration.
+ * The configuration must contain the translator engine class and options
+ * I.e.:
+ * 'Translators' => [
+ *   'deepl' => [
+ *      'name' => 'DeepL',
+ *      'class' => '\BEdita\I18n\Deepl\Core\Translator',
+ *      'options' => [
+ *        'auth_key' => '************',
+ *      ],
+ *   ],
+ * ],
+ */
+class TranslateObjectsCommand extends Command
+{
+    use InstanceConfigTrait;
+
+    protected $dryRun;
+    protected $defaultStatus;
+    protected $translatableFields = [];
+    protected $translator;
+    protected $langsMap = [
+        'en' => 'en-US',
+        'it' => 'it-IT',
+        'de' => 'de-DE',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        $parser = parent::buildOptionParser($parser);
+        $parser->addOption('from', [
+            'short' => 'f',
+            'help' => 'Language to translate from',
+            'required' => true,
+            'choices' => ['en', 'it', 'de'],
+        ]);
+        $parser->addOption('to', [
+            'short' => 't',
+            'help' => 'Language to translate to',
+            'required' => true,
+            'choices' => ['en', 'it', 'de'],
+        ]);
+        $parser->addOption('engine', [
+            'short' => 'e',
+            'help' => 'Translator engine',
+            'default' => 'deepl',
+            'required' => true,
+            'choices' => ['aws', 'deepl', 'google', 'microsoft'],
+        ]);
+        $parser->addOption('status', [
+            'short' => 's',
+            'help' => 'Status for new translations',
+            'choices' => ['draft', 'on', 'off'],
+            'default' => 'draft',
+        ]);
+        $parser->addOption('dry-run', [
+            'short' => 'd',
+            'help' => 'Dry run',
+            'boolean' => true,
+            'default' => false,
+        ]);
+
+        return $parser;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        $this->dryRun = $args->getOption('dry-run');
+
+        // parameter engine
+        $engine = $args->getOption('engine') ?? 'deepl';
+
+        // setup translator engine
+        $cfg = Configure::read(sprintf('Translators.%s', $engine));
+        if (empty($cfg)) {
+            $io->abort(sprintf('Translator %s not found', $engine));
+        }
+        $class = (string)Hash::get($cfg, 'class');
+        $options = (array)Hash::get($cfg, 'options');
+        $this->translator = new $class();
+        $this->translator->setup($options);
+
+        // parameters: lang from, lang to
+        $from = $args->getOption('from');
+        $to = $args->getOption('to');
+        $to = $this->langsMap['en'];
+        $io->out(sprintf('Translating objects from %s to %s [dry-run %s]', $from, $to, $this->dryRun ? 'yes' : 'no'));
+        if ($io->ask('Do you want to continue [Y/n]?', 'n') !== 'Y') {
+            $io->abort('Bye');
+        }
+
+        $ok = $error = 0;
+        $conditions = [];
+        $this->defaultStatus = $args->getOption('status');
+        foreach ($this->objectsIterator($conditions, $from, $to) as $object) {
+            try {
+                $io->verbose(sprintf('Translating object %s', $object->id));
+                if (!$this->dryRun) {
+                    $this->translate($object, $from, $to);
+                }
+                $io->verbose(sprintf('Translated object %s', $object->id));
+                $ok++;
+            } catch (\Exception $e) {
+                $io->error(sprintf('Error translating object %s: %s', $object->id, $e->getMessage()));
+                $error++;
+            }
+        }
+        $io->out(sprintf('Processed %d objects (%d errors)', $ok + $error, $error));
+        $io->out('Done');
+    }
+
+    /**
+     * Get objects as iterable.
+     *
+     * @param array $conditions The conditions to filter objects.
+     * @param string $lang The language to use to find objects.
+     * @param string $to The language to translate objects to.
+     * @return iterable
+     */
+    private function objectsIterator(array $conditions, string $lang, string $to): iterable
+    {
+        $table = $this->fetchTable('objects');
+        $conditions = array_merge(
+            $conditions,
+            [
+                $table->aliasField('deleted') => 0,
+                $table->aliasField('lang') => $lang,
+            ]
+        );
+        $query = $table->find('all')
+            ->where($conditions)
+            ->notMatching('Translations', function ($q) use ($to) {
+                return $q->where(['Translations.lang' => $to]);
+            })
+            ->orderAsc($table->aliasField('id'))
+            ->limit(500);
+        $lastId = 0;
+        while (true) {
+            $q = clone $query;
+            $q = $q->where(fn (QueryExpression $exp): QueryExpression => $exp->gt($table->aliasField('id'), $lastId));
+            $results = $q->all();
+            if ($results->isEmpty()) {
+                break;
+            }
+
+            foreach ($results as $entity) {
+                $lastId = $entity->id;
+
+                yield $entity;
+            }
+        }
+    }
+
+    /**
+     * Translate object translatable fields and store translation in translations table.
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectEntity $object The object to translate
+     * @param string $from The language to translate from
+     * @param string $to The language to translate to
+     * @return mixed
+     */
+    protected function translate($object, $from, $to)
+    {
+        $translatableFields = $this->translatableFields($object->type);
+        if (empty($translatableFields)) {
+            return;
+        }
+        $translatedFields = [];
+        foreach ($translatableFields as $field) {
+            if (empty($object->get($field))) {
+                continue;
+            }
+            $translatedFields[$field] = $this->singleTranslation($object->get($field), $from, $to);
+        }
+        $translation = [
+            'object_id' => $object->id,
+            'lang' => array_flip($this->langsMap)[$to],
+            'translated_fields' => json_encode($translatedFields),
+            'status' => $this->defaultStatus,
+        ];
+        $table = $this->fetchTable('Translations');
+        $entity = $table->newEntity($translation);
+        $entity->set('translated_fields', json_decode($translation['translated_fields'], true));
+        $entity->set('status', $this->defaultStatus);
+        LoggedUser::setUserAdmin();
+        $table->saveOrFail($entity);
+    }
+
+    /**
+     * Get translatable fields by object type.
+     *
+     * @param string $type The object type
+     * @return array
+     */
+    protected function translatableFields(string $type): array
+    {
+        if (array_key_exists($type, $this->translatableFields)) {
+            return $this->translatableFields[$type];
+        }
+        /** @var \BEdita\Core\Model\Entity\ObjectType $objectType */
+        $objectType = $this->fetchTable('ObjectTypes')->find()->where(['name' => $type])->firstOrFail();
+        $schema = $objectType->get('schema');
+        $this->translatableFields[$type] = (array)Hash::get($schema, 'translatable');
+
+        return $this->translatableFields[$type];
+    }
+
+    /**
+     * Translate a single text.
+     *
+     * @param mixed $text The text to translate
+     * @param string $from The language to translate from
+     * @param string $to The language to translate to
+     * @return string
+     */
+    protected function singleTranslation($text, string $from, string $to): string
+    {
+        $response = $this->translator->translate([$text], $from, $to);
+        $response = json_decode($response, true);
+
+        return (string)Hash::get($response, 'translation.0');
+    }
+}

--- a/src/Command/TranslateObjectsCommand.php
+++ b/src/Command/TranslateObjectsCommand.php
@@ -328,8 +328,10 @@ class TranslateObjectsCommand extends Command
      */
     public function translate($object, $from, $to): void
     {
-        $object = $this->fetchTable($object->type)->find()->where(['id' => $object->id])->firstOrFail();
-        $translatableFields = $this->translatableFields($object->type);
+        $id = $object->id;
+        $type = $object->type;
+        $object = $this->fetchTable($type)->find()->where(compact('id'))->firstOrFail();
+        $translatableFields = $this->translatableFields($type);
         if (empty($translatableFields)) {
             return;
         }
@@ -347,7 +349,7 @@ class TranslateObjectsCommand extends Command
             $translatedFields[$fields[$i]] = $t;
         }
         $translation = [
-            'object_id' => $object->id,
+            'object_id' => $id,
             'lang' => array_flip($this->langsMap)[$to],
             'translated_fields' => json_encode($translatedFields),
             'status' => $this->defaultStatus,

--- a/src/Command/TranslateObjectsCommand.php
+++ b/src/Command/TranslateObjectsCommand.php
@@ -44,6 +44,18 @@ class TranslateObjectsCommand extends Command
 {
     use InstanceConfigTrait;
 
+    protected $_defaultConfig = [
+        'langsMap' => [
+            'en' => 'en-US',
+            'it' => 'it-IT',
+            'de' => 'de-DE',
+            'es' => 'es-ES',
+            'fr' => 'fr-FR',
+            'pt' => 'pt-PT',
+        ],
+        'status' => 'draft',
+        'dryRun' => false,
+    ];
     protected $ok;
     protected $error;
     protected $io;
@@ -51,29 +63,39 @@ class TranslateObjectsCommand extends Command
     protected $defaultStatus;
     protected $translatableFields = [];
     protected $translator;
-    protected $langsMap = [
-        'en' => 'en-US',
-        'it' => 'it-IT',
-        'de' => 'de-DE',
-    ];
+    protected $langsMap;
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $cfg = (array)Configure::read('TranslateObjects');
+        $cfg = array_merge($this->_defaultConfig, $cfg);
+        $this->defaultStatus = (string)Hash::get($cfg, 'status');
+        $this->dryRun = (int)Hash::get($cfg, 'dryRun');
+        $this->langsMap = (array)Hash::get($cfg, 'langsMap');
+    }
 
     /**
      * @inheritDoc
      */
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
+        $langs = array_keys($this->langsMap);
         $parser = parent::buildOptionParser($parser);
         $parser->addOption('from', [
             'short' => 'f',
             'help' => 'Language to translate from',
             'required' => true,
-            'choices' => ['en', 'it', 'de'],
+            'choices' => $langs,
         ]);
         $parser->addOption('to', [
             'short' => 't',
             'help' => 'Language to translate to',
             'required' => true,
-            'choices' => ['en', 'it', 'de'],
+            'choices' => $langs,
         ]);
         $parser->addOption('engine', [
             'short' => 'e',

--- a/src/Command/TranslateObjectsCommand.php
+++ b/src/Command/TranslateObjectsCommand.php
@@ -67,6 +67,7 @@ class TranslateObjectsCommand extends Command
     protected $translator;
     protected $langsMap;
     protected $limit;
+    protected $type;
 
     /**
      * @inheritDoc

--- a/src/Command/TranslateObjectsCommand.php
+++ b/src/Command/TranslateObjectsCommand.php
@@ -344,6 +344,9 @@ class TranslateObjectsCommand extends Command
             $fields[] = $field;
             $values[] = $object->get($field);
         }
+        if (empty($fields)) {
+            return;
+        }
         $tr = $this->multiTranslation($values, $from, $to);
         foreach ($tr as $i => $t) {
             $translatedFields[$fields[$i]] = $t;

--- a/src/Command/TranslateObjectsCommand.php
+++ b/src/Command/TranslateObjectsCommand.php
@@ -136,10 +136,7 @@ class TranslateObjectsCommand extends Command
         if (empty($cfg)) {
             $this->io->abort(sprintf('Translator %s not found', $engine));
         }
-        $class = (string)Hash::get($cfg, 'class');
-        $options = (array)Hash::get($cfg, 'options');
-        $this->translator = new $class();
-        $this->translator->setup($options);
+        $this->setTranslator($cfg);
 
         // parameters: lang from, lang to
         $from = $args->getOption('from');
@@ -157,13 +154,27 @@ class TranslateObjectsCommand extends Command
     }
 
     /**
+     * Set translator engine.
+     *
+     * @param array $cfg The translator configuration
+     * @return void
+     */
+    public function setTranslator(array $cfg): void
+    {
+        $class = (string)Hash::get($cfg, 'class');
+        $options = (array)Hash::get($cfg, 'options');
+        $this->translator = new $class();
+        $this->translator->setup($options);
+    }
+
+    /**
      * Process objects to translate.
      *
      * @param string $from The language to translate from
      * @param string $to The language to translate to
      * @return void
      */
-    private function processObjects(string $from, string $to)
+    public function processObjects(string $from, string $to)
     {
         $conditions = [];
         foreach ($this->objectsIterator($conditions, $from, $to) as $object) {
@@ -189,7 +200,7 @@ class TranslateObjectsCommand extends Command
      * @param string $to The language to translate objects to.
      * @return iterable
      */
-    private function objectsIterator(array $conditions, string $lang, string $to): iterable
+    public function objectsIterator(array $conditions, string $lang, string $to): iterable
     {
         $table = $this->fetchTable('objects');
         $conditions = array_merge(
@@ -231,7 +242,7 @@ class TranslateObjectsCommand extends Command
      * @param string $to The language to translate to
      * @return void
      */
-    protected function translate($object, $from, $to): void
+    public function translate($object, $from, $to): void
     {
         $translatableFields = $this->translatableFields($object->type);
         if (empty($translatableFields)) {
@@ -264,7 +275,7 @@ class TranslateObjectsCommand extends Command
      * @param string $type The object type
      * @return array
      */
-    protected function translatableFields(string $type): array
+    public function translatableFields(string $type): array
     {
         if (array_key_exists($type, $this->translatableFields)) {
             return $this->translatableFields[$type];
@@ -285,7 +296,7 @@ class TranslateObjectsCommand extends Command
      * @param string $to The language to translate to
      * @return string
      */
-    protected function singleTranslation($text, string $from, string $to): string
+    public function singleTranslation($text, string $from, string $to): string
     {
         $response = $this->translator->translate([$text], $from, $to);
         $response = json_decode($response, true);

--- a/src/Command/TranslateObjectsCommand.php
+++ b/src/Command/TranslateObjectsCommand.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace BEdita\ImportTools\Command;
 
 use BEdita\Core\Model\Entity\ObjectEntity;
-use BEdita\Core\Model\Table\ObjectsTable;
 use BEdita\Core\Utility\JsonSchema;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Command\Command;

--- a/src/Command/TranslateObjectsCommand.php
+++ b/src/Command/TranslateObjectsCommand.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\ImportTools\Command;
 
 use BEdita\Core\Model\Entity\ObjectEntity;
+use BEdita\Core\Model\Table\ObjectsTable;
 use BEdita\Core\Utility\JsonSchema;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Command\Command;
@@ -293,6 +294,7 @@ class TranslateObjectsCommand extends Command
      */
     public function objectsIterator(array $conditions, string $lang, string $to): iterable
     {
+        /** @var \BEdita\Core\Model\Table\ObjectsTable $table */
         $table = $this->fetchTable('objects');
         if ($this->type !== null) {
             $conditions[$table->aliasField('object_type_id')] = $table->objectType($this->type)->id;

--- a/tests/TestCase/Command/TranslateFileCommandTest.php
+++ b/tests/TestCase/Command/TranslateFileCommandTest.php
@@ -21,9 +21,9 @@ use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**
- * {@see \App\Command\TranslateFileCommand} Test Case
+ * {@see \BEdita\ImportTools\Command\TranslateFileCommand} Test Case
  *
- * @coversDefaultClass \App\Command\TranslateFileCommand
+ * @coversDefaultClass \BEdita\ImportTools\Command\TranslateFileCommand
  */
 class TranslateFileCommandTest extends TestCase
 {

--- a/tests/TestCase/Command/TranslateFileCommandTest.php
+++ b/tests/TestCase/Command/TranslateFileCommandTest.php
@@ -60,7 +60,7 @@ class TranslateFileCommandTest extends TestCase
      */
     public function testExecuteNoTranslator(): void
     {
-        $input = sprintf('%s/tests/files/input.txt', ROOT);
+        $input = sprintf('%s/files/input.txt', ROOT);
         $this->exec('translate_file -i ' . $input . ' -o output.txt -f en -t it -e mytranslator');
         $this->assertErrorContains('No translator engine "mytranslator" is set in configuration');
     }
@@ -74,10 +74,10 @@ class TranslateFileCommandTest extends TestCase
      */
     public function testExecute(): void
     {
-        $input = sprintf('%s/tests/files/input.txt', ROOT);
-        $output = sprintf('%s/tests/files/output.txt', ROOT);
+        $input = sprintf('%s/files/input.txt', ROOT);
+        $output = sprintf('%s/files/output.txt', ROOT);
         Configure::write('Translators.dummy', [
-            'class' => 'App\Test\TestCase\Core\I18n\DummyTranslator',
+            'class' => 'BEdita\ImportTools\Test\TestCase\Core\I18n\DummyTranslator',
             'options' => ['auth_key' => 'secret'],
         ]);
         $this->exec('translate_file -i ' . $input . ' -o ' . $output . ' -f en -t it -e dummy');

--- a/tests/TestCase/Command/TranslateFileCommandTest.php
+++ b/tests/TestCase/Command/TranslateFileCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\ImportTools\Test\TestCase\Command;
+
+use Cake\Command\Command;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \App\Command\TranslateFileCommand} Test Case
+ *
+ * @coversDefaultClass \App\Command\TranslateFileCommand
+ */
+class TranslateFileCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+    }
+
+    /**
+     * Test `execute` with code error on no file
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     * @covers ::execute()
+     */
+    public function testExecuteNoFile(): void
+    {
+        $this->exec('translate_file -i input.txt -o output.txt -f en -t it -e google');
+        $this->assertErrorContains('Input file "input.txt" does not exist');
+    }
+
+    /**
+     * Test `execute` with code error on no translator
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     * @covers ::execute()
+     */
+    public function testExecuteNoTranslator(): void
+    {
+        $input = sprintf('%s/tests/files/input.txt', ROOT);
+        $this->exec('translate_file -i ' . $input . ' -o output.txt -f en -t it -e mytranslator');
+        $this->assertErrorContains('No translator engine "mytranslator" is set in configuration');
+    }
+
+    /**
+     * Test `execute` with code success
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     * @covers ::execute()
+     */
+    public function testExecute(): void
+    {
+        $input = sprintf('%s/tests/files/input.txt', ROOT);
+        $output = sprintf('%s/tests/files/output.txt', ROOT);
+        Configure::write('Translators.dummy', [
+            'class' => 'App\Test\TestCase\Core\I18n\DummyTranslator',
+            'options' => ['auth_key' => 'secret'],
+        ]);
+        $this->exec('translate_file -i ' . $input . ' -o ' . $output . ' -f en -t it -e dummy');
+        $this->assertOutputContains('"' . $input . '" [en] -> "' . $output . '" [it] using "dummy" engine.');
+        $this->assertExitCode(Command::CODE_SUCCESS);
+    }
+}

--- a/tests/TestCase/Command/TranslateObjectsCommandTest.php
+++ b/tests/TestCase/Command/TranslateObjectsCommandTest.php
@@ -15,7 +15,9 @@ declare(strict_types=1);
 
 namespace BEdita\ImportTools\Test\TestCase\Command;
 
+use BEdita\Core\Model\Entity\Location;
 use BEdita\ImportTools\Command\TranslateObjectsCommand;
+use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
@@ -162,10 +164,44 @@ class TranslateObjectsCommandTest extends TestCase
      *
      * @return void
      * @covers ::processObjects()
+     * @covers ::results()
      */
     public function testProcessObjects(): void
     {
-        $this->markTestIncomplete('Not implemented yet.');
+        $from = 'en';
+        $to = 'it';
+        $command = new TranslateObjectsCommand();
+        $command->processObjects($from, $to);
+        $actual = $command->results();
+        $expected = 'Processed 0 objects (0 errors)';
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test `processObject` method
+     *
+     * @return void
+     * @covers ::processObject()
+     * @covers ::results()
+     * @covers ::getDryRun()
+     * @covers ::setDryRun()
+     * @covers ::getIo()
+     * @covers ::setIo()
+     */
+    public function testProcessObjectDryRun(): void
+    {
+        $from = 'en';
+        $to = 'it';
+        $object = new Location();
+        $object->set('id', 999);
+        $command = new TranslateObjectsCommand();
+        $command->setIo(new ConsoleIo());
+        $command->setDryRun(true);
+        $command->processObject($object, $from, $to);
+        $actual = $command->results();
+        $expected = 'Processed 1 objects (0 errors)';
+        $this->assertEquals($expected, $actual);
+        $this->assertTrue($command->getDryRun());
     }
 
     /**

--- a/tests/TestCase/Command/TranslateObjectsCommandTest.php
+++ b/tests/TestCase/Command/TranslateObjectsCommandTest.php
@@ -259,4 +259,30 @@ class TranslateObjectsCommandTest extends TestCase
         $this->assertNotEmpty($actual);
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * Test `multiTranslation` method
+     *
+     * @return void
+     * @covers ::multiTranslation()
+     * @covers ::setTranslator()
+     */
+    public function testMultipleTranslation(): void
+    {
+        $texts = ['Hello', 'world'];
+        $from = 'en';
+        $to = 'it';
+        $command = new TranslateObjectsCommand();
+        $command->setTranslator([
+            'class' => 'BEdita\ImportTools\Test\TestCase\Core\I18n\DummyTranslator',
+            'options' => ['auth_key' => 'secret'],
+        ]);
+        $actual = $command->multiTranslation($texts, $from, $to);
+        $expected = [
+            sprintf('text: %s, from: %s, to: %s', $texts[0], $from, $to),
+            sprintf('text: %s, from: %s, to: %s', $texts[1], $from, $to),
+        ];
+        $this->assertNotEmpty($actual);
+        $this->assertEquals($expected, $actual);
+    }
 }

--- a/tests/TestCase/Command/TranslateObjectsCommandTest.php
+++ b/tests/TestCase/Command/TranslateObjectsCommandTest.php
@@ -37,49 +37,66 @@ class TranslateObjectsCommandTest extends TestCase
         $this->useCommandRunner();
     }
 
+    /**
+     * Data provider for `testExecute` test case.
+     *
+     * @return array
+     */
     public function executeProvider(): array
     {
+        $conf = [
+            'TranslateObjects' => [
+                'langsMap' => [
+                    'en' => 'en-US',
+                    'it' => 'it-IT',
+                    'de' => 'de-DE',
+                ],
+                'status' => 'draft',
+                'dryRun' => false,
+            ],
+        ];
+
         return [
             'missing from' => [
                 'translate_objects',
                 ['Missing required option. The `from` option is required and has no default value'],
                 1,
-                null,
+                $conf,
                 [],
             ],
             'wrong from' => [
                 'translate_objects --from ita',
                 ['"ita" is not a valid value for --from. Please use one of "en, it, de"'],
                 1,
-                null,
+                $conf,
                 [],
             ],
             'missing to' => [
                 'translate_objects --from en',
                 ['Missing required option. The `to` option is required and has no default value'],
                 1,
-                null,
+                $conf,
                 [],
             ],
             'wrong to' => [
                 'translate_objects --from en --to ita',
                 ['"ita" is not a valid value for --to. Please use one of "en, it, de"'],
                 1,
-                null,
+                $conf,
                 [],
             ],
             'missing translator engine setup' => [
                 'translate_objects --from en --to it',
                 ['Translator deepl not found'],
                 1,
-                null,
+                $conf,
                 [],
             ],
             'continue? n' => [
                 'translate_objects --from en --to it',
                 ['Bye'],
                 1,
-                [
+                $conf + [
                     'Translators.deepl' => [
                         'class' => 'BEdita\ImportTools\Test\TestCase\Core\I18n\DummyTranslator',
                         'options' => ['auth_key' => 'secret'],
@@ -95,7 +112,7 @@ class TranslateObjectsCommandTest extends TestCase
                     'Done',
                 ],
                 0,
-                [
+                $conf + [
                     'Translators.deepl' => [
                         'class' => 'BEdita\ImportTools\Test\TestCase\Core\I18n\DummyTranslator',
                         'options' => ['auth_key' => 'secret'],
@@ -112,19 +129,17 @@ class TranslateObjectsCommandTest extends TestCase
      * @param string $cmd Command to execute
      * @param array $expected Expected messages in output
      * @param int $error Expected exit code
-     * @param array|null $config Configuration to set
+     * @param array $config Configuration to set
      * @param array $input Input to provide
      * @return void
      * @dataProvider executeProvider
      * @covers ::buildOptionParser()
      * @covers ::execute()
      */
-    public function testExecute(string $cmd, array $expected, int $error, ?array $config, array $input): void
+    public function testExecute(string $cmd, array $expected, int $error, array $config, array $input): void
     {
-        if ($config !== null) {
-            foreach ($config as $key => $value) {
-                Configure::write($key, $value);
-            }
+        foreach ($config as $key => $value) {
+            Configure::write($key, $value);
         }
         $this->exec($cmd, $input);
         if ($error === 0) {

--- a/tests/TestCase/Command/TranslateObjectsCommandTest.php
+++ b/tests/TestCase/Command/TranslateObjectsCommandTest.php
@@ -20,9 +20,9 @@ use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**
- * {@see \App\Command\TranslateObjectsCommand} Test Case
+ * {@see \BEdita\ImportTools\Command\TranslateObjectsCommand} Test Case
  *
- * @coversDefaultClass \App\Command\TranslateObjectsCommand
+ * @coversDefaultClass \BEdita\ImportTools\Command\TranslateObjectsCommand
  */
 class TranslateObjectsCommandTest extends TestCase
 {

--- a/tests/TestCase/Command/TranslateObjectsCommandTest.php
+++ b/tests/TestCase/Command/TranslateObjectsCommandTest.php
@@ -110,7 +110,7 @@ class TranslateObjectsCommandTest extends TestCase
             'continue? Y + dry-run yes' => [
                 'translate_objects --from en --to it --dry-run 1',
                 [
-                    'Translating objects from en to it [dry-run yes / limit unlimited / type all]',
+                    'Translating objects from en to it [dry-run yes / limit unlimited / all types]',
                     'Processed 0 objects (0 errors)',
                     'Done',
                 ],

--- a/tests/TestCase/Command/TranslateObjectsCommandTest.php
+++ b/tests/TestCase/Command/TranslateObjectsCommandTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace BEdita\ImportTools\Test\TestCase\Command;
 
+use BEdita\ImportTools\Command\TranslateObjectsCommand;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
@@ -205,9 +206,21 @@ class TranslateObjectsCommandTest extends TestCase
      *
      * @return void
      * @covers ::singleTranslation()
+     * @covers ::setTranslator()
      */
     public function testSingleTranslation(): void
     {
-        $this->markTestIncomplete('Not implemented yet.');
+        $text = 'Hello, world!';
+        $from = 'en';
+        $to = 'it';
+        $command = new TranslateObjectsCommand();
+        $command->setTranslator([
+            'class' => 'BEdita\ImportTools\Test\TestCase\Core\I18n\DummyTranslator',
+            'options' => ['auth_key' => 'secret'],
+        ]);
+        $actual = $command->singleTranslation($text, $from, $to);
+        $expected = sprintf('text: %s, from: %s, to: %s', $text, $from, $to);
+        $this->assertNotEmpty($actual);
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/TestCase/Command/TranslateObjectsCommandTest.php
+++ b/tests/TestCase/Command/TranslateObjectsCommandTest.php
@@ -110,7 +110,7 @@ class TranslateObjectsCommandTest extends TestCase
             'continue? Y + dry-run yes' => [
                 'translate_objects --from en --to it --dry-run 1',
                 [
-                    'Translating objects from en to it [dry-run yes]',
+                    'Translating objects from en to it [dry-run yes / limit unlimited]',
                     'Processed 0 objects (0 errors)',
                     'Done',
                 ],

--- a/tests/TestCase/Command/TranslateObjectsCommandTest.php
+++ b/tests/TestCase/Command/TranslateObjectsCommandTest.php
@@ -135,6 +135,7 @@ class TranslateObjectsCommandTest extends TestCase
      * @dataProvider executeProvider
      * @covers ::buildOptionParser()
      * @covers ::execute()
+     * @covers ::__construct()
      */
     public function testExecute(string $cmd, array $expected, int $error, array $config, array $input): void
     {

--- a/tests/TestCase/Command/TranslateObjectsCommandTest.php
+++ b/tests/TestCase/Command/TranslateObjectsCommandTest.php
@@ -110,7 +110,7 @@ class TranslateObjectsCommandTest extends TestCase
             'continue? Y + dry-run yes' => [
                 'translate_objects --from en --to it --dry-run 1',
                 [
-                    'Translating objects from en to it [dry-run yes / limit unlimited]',
+                    'Translating objects from en to it [dry-run yes / limit unlimited / type all]',
                     'Processed 0 objects (0 errors)',
                     'Done',
                 ],

--- a/tests/TestCase/Command/TranslateObjectsCommandTest.php
+++ b/tests/TestCase/Command/TranslateObjectsCommandTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\ImportTools\Test\TestCase\Command;
+
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \App\Command\TranslateObjectsCommand} Test Case
+ *
+ * @coversDefaultClass \App\Command\TranslateObjectsCommand
+ */
+class TranslateObjectsCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+    }
+
+    /**
+     * Test `execute` with code error on no file
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     * @covers ::execute()
+     */
+    public function testExecute(): void
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test `objectsIterator` method
+     *
+     * @return void
+     * @covers ::objectsIterator()
+     */
+    public function testObjectsIterator(): void
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test `translate` method
+     *
+     * @return void
+     * @covers ::translate()
+     */
+    public function testTranslate(): void
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test `translatableFields` method
+     *
+     * @return void
+     * @covers ::translatableFields()
+     */
+    public function testTranslatableFields(): void
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test `singleTranslation` method
+     *
+     * @return void
+     * @covers ::singleTranslation()
+     */
+    public function testSingleTranslation(): void
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+}

--- a/tests/TestCase/Core/I18n/DummyTranslator.php
+++ b/tests/TestCase/Core/I18n/DummyTranslator.php
@@ -1,0 +1,51 @@
+<?php
+namespace BEdita\ImportTools\Test\TestCase\Core\I18n;
+
+use BEdita\I18n\Core\TranslatorInterface;
+
+class DummyTranslator implements TranslatorInterface
+{
+    /**
+     * The engine options.
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
+     * Setup translator engine.
+     *
+     * @param array $options The options
+     * @return void
+     */
+    public function setup(array $options = []): void
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * Translate an array of texts $texts from language source $from to language target $to
+     *
+     * @param array $texts The texts to translate
+     * @param string $from The source language
+     * @param string $to The target language
+     * @return string The translation in json format as string, i.e.
+     * {
+     *     "translation": [
+     *         "<translation of first text>",
+     *         "<translation of second text>",
+     *         [...]
+     *         "<translation of last text>"
+     *     ]
+     * }
+     */
+    public function translate(array $texts, string $from, string $to): string
+    {
+        $translation = [];
+        foreach ($texts as $text) {
+            $translation[] = sprintf('text: %s, from: %s, to: %s', $text, $from, $to);
+        }
+
+        return json_encode(compact('translation'));
+    }
+}

--- a/tests/TestCase/Core/I18n/DummyTranslator.php
+++ b/tests/TestCase/Core/I18n/DummyTranslator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace BEdita\ImportTools\Test\TestCase\Core\I18n;
 
 use BEdita\I18n\Core\TranslatorInterface;

--- a/tests/TestCase/Utility/ImportTest.php
+++ b/tests/TestCase/Utility/ImportTest.php
@@ -52,7 +52,6 @@ class ImportTest extends TestCase
      * Test constructor
      *
      * @return void
-     * @covers ::__construct()
      */
     public function testConstructor(): void
     {
@@ -140,7 +139,6 @@ class ImportTest extends TestCase
      * @param array $expected Expected
      * @return void
      * @dataProvider saveObjectsProvider
-     * @covers ::saveObjects()
      */
     public function testSaveObjects(string $filename, string $type, string $parent, bool $dryrun, array $expected): void
     {
@@ -206,7 +204,6 @@ class ImportTest extends TestCase
      * @param array $expected Expected
      * @return void
      * @dataProvider saveObjectProvider
-     * @covers ::saveObject()
      */
     public function testSaveObject(string $f, string $t, string $p, bool $dr, array $data, array $expected): void
     {
@@ -238,7 +235,6 @@ class ImportTest extends TestCase
      *
      * @return void
      * @dataProvider saveObjectProvider
-     * @covers ::saveObject()
      */
     public function testSaveObjectWhenExists(): void
     {
@@ -269,7 +265,6 @@ class ImportTest extends TestCase
      *
      * @return void
      * @dataProvider saveObjectProvider
-     * @covers ::saveObject()
      */
     public function testSaveObjectWhenExistsWrongType(): void
     {
@@ -365,7 +360,6 @@ class ImportTest extends TestCase
      * @param array $exp Expected
      * @return void
      * @dataProvider saveTranslationsWithErrorProvider
-     * @covers ::saveTranslations()
      */
     public function testSaveTranslationsWithError(string $f, string $t, string $p, bool $dr, array $exp): void
     {
@@ -428,7 +422,6 @@ class ImportTest extends TestCase
      * @param array $exp Expected
      * @return void
      * @dataProvider saveTranslationsProvider
-     * @covers ::saveTranslations()
      */
     public function testSaveTranslations(string $arf, string $trf, bool $trdr, array $exp): void
     {
@@ -477,8 +470,6 @@ class ImportTest extends TestCase
      *
      * @return void
      * @dataProvider saveTranslationProvider
-     * @covers ::saveTranslation()
-     * @covers ::translatedFields()
      */
     public function testSaveTranslation(string $f, bool $dr, array $data, array $expected): void
     {
@@ -544,7 +535,6 @@ class ImportTest extends TestCase
      *
      * @return void
      * @dataProvider translatedFieldsProvider
-     * @covers ::translatedFields()
      */
     public function testTranslatedFields(array $data, array $expected): void
     {

--- a/tests/TestCase/Utility/TreeTraitTest.php
+++ b/tests/TestCase/Utility/TreeTraitTest.php
@@ -62,6 +62,9 @@ class TreeTraitTest extends TestCase
         LoggedUser::setUserAdmin();
     }
 
+    /**
+     * @inheritDoc
+     */
     public function tearDown(): void
     {
         $this->getTableLocator()->clear();
@@ -73,7 +76,6 @@ class TreeTraitTest extends TestCase
      * Test `setParent` method
      *
      * @return void
-     * @covers ::setParent()
      */
     public function testSetParent(): void
     {

--- a/tests/files/input.txt
+++ b/tests/files/input.txt
@@ -1,0 +1,1 @@
+Some text in here


### PR DESCRIPTION
This provides two commands to handle translations:

 - TranslateFileCommand: translate an input file to an output file using a translation engine

```
// translate file input.txt into output.txt, from english to italian, using "google" engine
$ bin/cake translate_file -i input.txt -o output.txt -f en -t it -e google
```

 - TranslateObjectsCommand: create objects translations from a language to another language using a translation engine

```
// translate documents from italian to german, verbose log
$ bin/cake translate_objects --from it --to de --object-type documents --verbose

// translate objects from english to italian, dry-run mode, unlimited
$ bin/cake translate_objects --from en --to it --dry-run 1

// translate objects from italian to deutsch, created translations status will be off, limit to 10 objects
$ bin/cake translate_objects --from it --to de --status off --limit 10

// use "google" as engine
$ bin/cake translate_objects --engine google --from it --to de
```

This also updates bedita api and core to v5.22.