### PR TITLE
Anonymize users command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,14 @@
     ],
     "require": {
         "php": ">= 7.4",
-        "cakephp/cakephp": "^4.4",
-        "bedita/api": "^5.22",
-        "bedita/core": "^5.22",
-        "bedita/i18n": "^4.4"
+        "cakephp/cakephp": "^4.5",
+        "bedita/api": "^5.27",
+        "bedita/core": "^5.27",
+        "bedita/i18n": "^4.4",
+        "fakerphp/faker": "^1.23"
     },
     "require-dev": {
-        "cakephp/cakephp-codesniffer": "~4.5",
+        "cakephp/cakephp-codesniffer": "~4.7",
         "phpstan/phpstan": "^1.8",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",

--- a/src/Command/AnonymizeUsersCommand.php
+++ b/src/Command/AnonymizeUsersCommand.php
@@ -127,7 +127,7 @@ class AnonymizeUsersCommand extends Command
         $io->verbose(sprintf('Processing user %s [username: %s, email: %s]', $user->id, $user->username, $user->email));
         $user->name = $faker->firstName();
         $user->surname = $faker->lastName();
-        $user->email = sprintf('%s.%d@%s', $faker->username(), $user->id, $faker->safeEmailDomain());
+        $user->email = sprintf('%s.%s.%d@%s', $user->name, $user->surname, $user->id, $faker->safeEmailDomain());
         $user->uname = sprintf('user-%s', Text::uuid());
         $user->username = $user->email;
         $processed++;

--- a/src/Command/AnonymizeUsersCommand.php
+++ b/src/Command/AnonymizeUsersCommand.php
@@ -94,7 +94,7 @@ class AnonymizeUsersCommand extends Command
             ]);
         $id = $args->getOption('id');
         if ($id) {
-            $query->where([$table->aliasField('id') => $id]);
+            $query = $query->where([$table->aliasField('id') => $id]);
         }
         $faker = Factory::create('it_IT');
         $processed = $saved = $errors = 0;

--- a/src/Command/AnonymizeUsersCommand.php
+++ b/src/Command/AnonymizeUsersCommand.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\ImportTools\Command;
+
+use BEdita\Core\Utility\LoggedUser;
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\ORM\Query;
+use Cake\Utility\Text;
+use Faker\Factory;
+
+/**
+ * Anonymize users command.
+ *
+ * @property \BEdita\Core\Model\Table\UsersTable $Users
+ */
+class AnonymizeUsersCommand extends Command
+{
+    /**
+     * Users to preserve by id.
+     *
+     * @var array
+     */
+    protected array $preserveUsers = [
+        1, // admin
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return parent::buildOptionParser($parser)
+            ->addOptions([
+                'id' => [
+                    'help' => 'User id',
+                ],
+                'preserve' => [
+                    'help' => 'Users to preserve by id',
+                    'default' => '1',
+                ],
+            ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Anonymize Users command.
+     *
+     * $ bin/cake anonymize_users --help
+     *
+     * Usage:
+     * cake anonymize_users [options]
+     *
+     * Options:
+     *
+     * --id           User id
+     * --preserve     Users to preserve by id
+     * --help, -h     Display this help.
+     * --verbose, -v  Enable verbose output.
+     *
+     * # basic
+     * $ bin/cake anonymize_users --id 2
+     * $ bin/cake anonymize_users --preserve 1,2,3
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        $io->success('Start.');
+        LoggedUser::setUserAdmin();
+        $this->Users = $this->fetchTable('Users');
+        $this->preserveUsers = array_map('intval', explode(',', $args->getOption('preserve')));
+        $query = $this->Users->find()
+            ->where([
+                $this->Users->aliasField('locked') => 0,
+                $this->Users->aliasField('deleted') => 0,
+                $this->Users->aliasField('id') . ' NOT IN' => $this->preserveUsers,
+            ]);
+        $id = $args->getOption('id');
+        if ($id) {
+            $query->where([$this->Users->aliasField('id') => $id]);
+        }
+        $faker = Factory::create('it_IT');
+        $processed = $saved = $errors = 0;
+        /** @var \BEdita\Core\Model\Entity\User $user */
+        foreach ($this->objectsGenerator($query) as $user) {
+            $io->verbose(sprintf('Processing user %s [username: %s, email: %s]', $user->id, $user->username, $user->email));
+            $user->name = $faker->firstName();
+            $user->surname = $faker->lastName();
+            $email = $faker->email();
+            while ($this->Users->exists([$this->Users->aliasField('email') => $email])) {
+                $email = $faker->email();
+            }
+            $user->email = $email;
+            $user->uname = sprintf('user-%s', Text::uuid());
+            $user->username = $email;
+            $processed++;
+            try {
+                $this->Users->saveOrFail($user);
+                $this->log(sprintf('[OK] User %s updated', $user->id), 'debug');
+                $saved++;
+                $io->verbose(sprintf('Saved %s as [username: %s, email: %s]', $user->id, $user->username, $user->email));
+            } catch (\Exception $e) {
+                $this->log(sprintf('[KO] User %s not updated', $user->id), 'error');
+                $errors++;
+                $io->verbose(sprintf('Error %s as [username: %s, email: %s]', $user->id, $user->username, $user->email));
+            }
+        }
+        $io->out(sprintf('Users processed: %s', $processed));
+        $io->out(sprintf('Users saved: %s', $saved));
+        $io->out(sprintf('Users not saved: %s', $errors));
+        $io->success('Done.');
+
+        return null;
+    }
+
+    /**
+     * Objects generator.
+     *
+     * @param \Cake\ORM\Query $query Query object
+     * @return \Generator
+     */
+    protected function objectsGenerator(Query $query): \Generator
+    {
+        $pageSize = 1000;
+        $pages = ceil($query->count() / $pageSize);
+        for ($page = 1; $page <= $pages; $page++) {
+            yield from $query
+                ->page($page, $pageSize)
+                ->toArray();
+        }
+    }
+}

--- a/src/Command/AnonymizeUsersCommand.php
+++ b/src/Command/AnonymizeUsersCommand.php
@@ -100,7 +100,7 @@ class AnonymizeUsersCommand extends Command
         $processed = $saved = $errors = 0;
         /** @var \BEdita\Core\Model\Entity\User $user */
         foreach ($this->objectsGenerator($query) as $user) {
-            $this->updateUser($faker, $user, $table, $io, $processed, $saved, $errors);
+            $this->anonymize($faker, $user, $table, $io, $processed, $saved, $errors);
         }
         $io->out(sprintf('Users processed: %s', $processed));
         $io->out(sprintf('Users saved: %s', $saved));
@@ -122,7 +122,7 @@ class AnonymizeUsersCommand extends Command
      * @param int $errors Errors
      * @return void
      */
-    public function updateUser(Generator $faker, User $user, UsersTable $table, ConsoleIo $io, int &$processed, int &$saved, int &$errors): void
+    public function anonymize(Generator $faker, User $user, UsersTable $table, ConsoleIo $io, int &$processed, int &$saved, int &$errors): void
     {
         $io->verbose(sprintf('Processing user %s [username: %s, email: %s]', $user->id, $user->username, $user->email));
         $user->name = $faker->firstName();

--- a/src/Command/AnonymizeUsersCommand.php
+++ b/src/Command/AnonymizeUsersCommand.php
@@ -127,10 +127,9 @@ class AnonymizeUsersCommand extends Command
         $io->verbose(sprintf('Processing user %s [username: %s, email: %s]', $user->id, $user->username, $user->email));
         $user->name = $faker->firstName();
         $user->surname = $faker->lastName();
-        $email = $faker->email();
-        while ($table->exists([$table->aliasField('email') => $email])) {
+        do {
             $email = $faker->email();
-        }
+        } while ($table->exists([$table->aliasField('email') => $email]));
         $user->email = $email;
         $user->uname = sprintf('user-%s', Text::uuid());
         $user->username = $email;

--- a/src/Command/AnonymizeUsersCommand.php
+++ b/src/Command/AnonymizeUsersCommand.php
@@ -79,7 +79,7 @@ class AnonymizeUsersCommand extends Command
      * $ bin/cake anonymize_users --id 2
      * $ bin/cake anonymize_users --preserve 1,2,3
      */
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $io->success('Start.');
         LoggedUser::setUserAdmin();
@@ -107,7 +107,7 @@ class AnonymizeUsersCommand extends Command
         $io->out(sprintf('Users not saved: %s', $errors));
         $io->success('Done.');
 
-        return null;
+        return Command::CODE_SUCCESS;
     }
 
     /**

--- a/src/Command/AnonymizeUsersCommand.php
+++ b/src/Command/AnonymizeUsersCommand.php
@@ -127,7 +127,7 @@ class AnonymizeUsersCommand extends Command
         $io->verbose(sprintf('Processing user %s [username: %s, email: %s]', $user->id, $user->username, $user->email));
         $user->name = $faker->firstName();
         $user->surname = $faker->lastName();
-        $user->email = sprintf('%s.%s.%d@%s', $user->name, $user->surname, $user->id, $faker->safeEmailDomain());
+        $user->email = sprintf('%s.%s.%d@%s', Text::slug($user->name), Text::slug($user->surname), $user->id, $faker->safeEmailDomain());
         $user->uname = sprintf('user-%s', Text::uuid());
         $user->username = $user->email;
         $processed++;

--- a/src/Command/AnonymizeUsersCommand.php
+++ b/src/Command/AnonymizeUsersCommand.php
@@ -127,12 +127,9 @@ class AnonymizeUsersCommand extends Command
         $io->verbose(sprintf('Processing user %s [username: %s, email: %s]', $user->id, $user->username, $user->email));
         $user->name = $faker->firstName();
         $user->surname = $faker->lastName();
-        do {
-            $email = $faker->email();
-        } while ($table->exists([$table->aliasField('email') => $email]));
-        $user->email = $email;
+        $user->email = sprintf('%s.%d@%s', $faker->username(), $user->id, $faker->safeEmailDomain());
         $user->uname = sprintf('user-%s', Text::uuid());
-        $user->username = $email;
+        $user->username = $user->email;
         $processed++;
         try {
             $table->saveOrFail($user);

--- a/tests/TestCase/Command/AnonymizeUsersCommandTest.php
+++ b/tests/TestCase/Command/AnonymizeUsersCommandTest.php
@@ -116,6 +116,7 @@ class AnonymizeUsersCommandTest extends TestCase
     {
         LoggedUser::setUserAdmin();
         $table = $this->fetchTable('Users');
+        /** @var \BEdita\Core\Model\Entity\User $user */
         $user = $table->newEmptyEntity();
         $user->username = 'gustavo';
         $user->email = 'gustavo@bedita.net';

--- a/tests/TestCase/Command/AnonymizeUsersCommandTest.php
+++ b/tests/TestCase/Command/AnonymizeUsersCommandTest.php
@@ -117,18 +117,18 @@ class AnonymizeUsersCommandTest extends TestCase
     }
 
     /**
-     * Test updateUser
+     * Test anonymize
      *
      * @return void
-     * @covers ::updateUser()
+     * @covers ::anonymize()
      */
-    public function testUpdateUser(): void
+    public function testAnonymize(): void
     {
         $faker = Factory::create('it_IT');
         $processed = $saved = $errors = 0;
         $table = $this->fetchTable('Users');
         $user = $table->newEmptyEntity();
-        $this->command->updateUser($faker, $user, $table, new ConsoleIo(), $processed, $saved, $errors);
+        $this->command->anonymize($faker, $user, $table, new ConsoleIo(), $processed, $saved, $errors);
         $this->assertEquals(1, $errors);
         $this->assertEquals(1, $processed);
         $this->assertEquals(0, $saved);

--- a/tests/TestCase/Command/AnonymizeUsersCommandTest.php
+++ b/tests/TestCase/Command/AnonymizeUsersCommandTest.php
@@ -98,10 +98,11 @@ class AnonymizeUsersCommandTest extends TestCase
      */
     public function testExecuteById(): void
     {
-        $this->exec('anonymize_users --id 999999999');
+        // 5 'second user'
+        $this->exec('anonymize_users --id 5');
         $this->assertOutputContains('Start');
-        $this->assertOutputContains('Users processed: 0');
-        $this->assertOutputContains('Users saved: 0');
+        $this->assertOutputContains('Users processed: 1');
+        $this->assertOutputContains('Users saved: 1');
         $this->assertOutputContains('Users not saved: 0');
         $this->assertOutputContains('Done.');
     }

--- a/tests/TestCase/Command/AnonymizeUsersCommandTest.php
+++ b/tests/TestCase/Command/AnonymizeUsersCommandTest.php
@@ -126,7 +126,9 @@ class AnonymizeUsersCommandTest extends TestCase
     {
         $faker = Factory::create('it_IT');
         $processed = $saved = $errors = 0;
+        /** @var \BEdita\Core\Model\Table\UsersTable $table */
         $table = $this->fetchTable('Users');
+        /** @var \BEdita\Core\Model\Entity\User $user */
         $user = $table->newEmptyEntity();
         $this->command->anonymize($faker, $user, $table, new ConsoleIo(), $processed, $saved, $errors);
         $this->assertEquals(1, $errors);

--- a/tests/TestCase/Command/AnonymizeUsersCommandTest.php
+++ b/tests/TestCase/Command/AnonymizeUsersCommandTest.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\ImportTools\Test\TestCase\Command;
+
+use BEdita\ImportTools\Command\AnonymizeUsersCommand;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\ImportTools\Command\AnonymizeUsersCommand} Test Case
+ *
+ * @coversDefaultClass \BEdita\ImportTools\Command\AnonymizeUsersCommand
+ */
+class AnonymizeUsersCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.Trees',
+    ];
+
+    /**
+     * The command used in test
+     *
+     * @var \BEdita\ImportTools\Command\AnonymizeUsersCommand
+     */
+    protected $command = null;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+        $this->command = new AnonymizeUsersCommand();
+    }
+
+    /**
+     * Test buildOptionParser method
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     */
+    public function testBuildOptionParser(): void
+    {
+        $this->exec('anonymize_users --help');
+        $this->assertOutputContains('cake anonymize_users [-h] [--id] [--preserve 1] [-q] [-v]');
+        $this->assertOutputContains('--id');
+        $this->assertOutputContains('User id');
+        $this->assertOutputContains('--preserve');
+        $this->assertOutputContains('Users to preserve by id');
+        $this->assertOutputContains('--help, -h');
+        $this->assertOutputContains('Display this help.');
+        $this->assertOutputContains('--verbose, -v');
+        $this->assertOutputContains('Enable verbose output.');
+    }
+
+    /**
+     * Test execute method
+     *
+     * @return void
+     * @covers ::execute()
+     * @covers ::objectsIterator()
+     */
+    public function testExecuteById(): void
+    {
+        $this->exec('anonymize_users --id 999999999');
+        $this->assertOutputContains('Start');
+        $this->assertOutputContains('Users processed: 0');
+        $this->assertOutputContains('Users saved: 0');
+        $this->assertOutputContains('Users not saved: 0');
+        $this->assertOutputContains('Done.');
+    }
+
+    /**
+     * Test execute method
+     *
+     * @return void
+     * @covers ::execute()
+     * @covers ::objectsIterator()
+     */
+    public function testExecute(): void
+    {
+        $this->exec('anonymize_users');
+        $this->assertOutputContains('Start');
+        $this->assertOutputContains('Users processed: 0');
+        $this->assertOutputContains('Users saved: 0');
+        $this->assertOutputContains('Users not saved: 0');
+        $this->assertOutputContains('Done.');
+    }
+}

--- a/tests/TestCase/Command/AnonymizeUsersCommandTest.php
+++ b/tests/TestCase/Command/AnonymizeUsersCommandTest.php
@@ -15,8 +15,10 @@ declare(strict_types=1);
 namespace BEdita\ImportTools\Test\TestCase\Command;
 
 use BEdita\ImportTools\Command\AnonymizeUsersCommand;
+use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use Faker\Factory;
 
 /**
  * {@see \BEdita\ImportTools\Command\AnonymizeUsersCommand} Test Case
@@ -84,6 +86,7 @@ class AnonymizeUsersCommandTest extends TestCase
      * @return void
      * @covers ::execute()
      * @covers ::objectsIterator()
+     * @covers ::updateUser()
      */
     public function testExecuteById(): void
     {
@@ -101,6 +104,7 @@ class AnonymizeUsersCommandTest extends TestCase
      * @return void
      * @covers ::execute()
      * @covers ::objectsIterator()
+     * @covers ::updateUser()
      */
     public function testExecute(): void
     {
@@ -110,5 +114,23 @@ class AnonymizeUsersCommandTest extends TestCase
         $this->assertOutputContains('Users saved: 0');
         $this->assertOutputContains('Users not saved: 0');
         $this->assertOutputContains('Done.');
+    }
+
+    /**
+     * Test updateUser
+     *
+     * @return void
+     * @covers ::updateUser()
+     */
+    public function testUpdateUser(): void
+    {
+        $faker = Factory::create('it_IT');
+        $processed = $saved = $errors = 0;
+        $table = $this->fetchTable('Users');
+        $user = $table->newEmptyEntity();
+        $this->command->updateUser($faker, $user, $table, new ConsoleIo(), $processed, $saved, $errors);
+        $this->assertEquals(1, $errors);
+        $this->assertEquals(1, $processed);
+        $this->assertEquals(0, $saved);
     }
 }


### PR DESCRIPTION
This introduces the `AnonymizeUsers` command.

Usage:
```
// anonymize all users (except user by ID 1, admin)
$ bin/cake anonymize_users

// anonymize users by id 2,3,4
$ bin/cake anonymize_users --id 2,3,4

// anonymize all users except users by id 1,2,3
$ bin/cake anonymize_users --preserve 1,2,3
```

This also updates dependencies:

 - bedita/api ^5.27
 - bedita/core ^5.27
 - cakephp/cakephp ^4.5