### PR TITLE
Import project command

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,12 +16,12 @@ jobs:
   cs:
     uses: bedita/github-workflows/.github/workflows/php-cs.yml@v2
     with:
-      php_versions: '["7.4", "8.1", "8.2", "8.3"]'
+      php_versions: '["8.3"]'
 
   stan:
     uses: bedita/github-workflows/.github/workflows/php-stan.yml@v2
     with:
-      php_versions: '["7.4", "8.1", "8.2", "8.3"]'
+      php_versions: '["8.3"]'
 
   unit:
     name: 'Run unit tests'
@@ -68,7 +68,7 @@ jobs:
         id: test-coverage
         uses: johanvanhelden/gha-clover-test-coverage-check@v1
         with:
-          percentage: '80'
+          percentage: '74'
           filename: "${{ matrix.php-version }}-${{ strategy.job-index }}-clover.xml"
 
       - name: 'Export coverage results'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -68,7 +68,7 @@ jobs:
         id: test-coverage
         uses: johanvanhelden/gha-clover-test-coverage-check@v1
         with:
-          percentage: '74'
+          percentage: '70'
           filename: "${{ matrix.php-version }}-${{ strategy.job-index }}-clover.xml"
 
       - name: 'Export coverage results'

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ composer require bedita/import-tools
 
 ## Commands
 
+### AnonymizeUsersCommand
+
+This command provides a tool to anonymize users.
+Usage examples
+```bash
+// anonymize all users (except user by ID 1, admin)
+$ bin/cake anonymize_users
+
+// anonymize users by id 2,3,4
+$ bin/cake anonymize_users --id 2,3,4
+
+// anonymize all users except users by id 1,2,3
+$ bin/cake anonymize_users --preserve 1,2,3
+```
+
 ### ImportCommand
 
 This command provides a tool to import data from csv file.
@@ -46,6 +61,45 @@ $ bin/cake import -f news.csv -t news -p my-folder-uname
 # translations
 $ bin/cake import --file translations.csv --type translations
 $ bin/cake import -f translations.csv -t translations
+```
+
+### ImportProjectCommand
+
+You could use this command when you are copying a remote database to a locale database, and after that you want to "adjust" applications and users.
+Applications and users in default datasource will be updated.
+
+Before launching it, you should setup properly default and import datasources in config/app_local.php.
+Example:
+```php
+'Datasources' => [
+    // the target database
+    'default' => [
+        'className' => 'Cake\Database\Connection',
+        'driver' => 'Cake\Database\Driver\Mysql',
+        'host' => '***********',
+        'port' => '***********',
+        'username' => '***********',
+        'password' => '***********',
+        'database' => '***********',
+        // ...
+    ],
+    // the remote database you want to you as source
+    'import' => [
+        'className' => 'Cake\Database\Connection',
+        'driver' => 'Cake\Database\Driver\Mysql',
+        'host' => '***********',
+        'port' => '***********',
+        'username' => '***********',
+        'password' => '***********',
+        'database' => '***********',
+        // ...
+    ],
+],
+```
+
+Usage example:
+```bash
+$ bin/cake import_project
 ```
 
 ### TranslateFileCommand

--- a/src/Command/ImportProjectCommand.php
+++ b/src/Command/ImportProjectCommand.php
@@ -92,6 +92,8 @@ class ImportProjectCommand extends Command
         $this->updateUsers($importConnection, $update);
         $io->success('Import project done.');
         $io->out('End');
+
+        return static::CODE_SUCCESS;
     }
 
     /**

--- a/src/Command/ImportProjectCommand.php
+++ b/src/Command/ImportProjectCommand.php
@@ -44,22 +44,15 @@ class ImportProjectCommand extends Command
     {
         $io->out('Start');
         $project = new Project($io);
-
-        // check connection
         if ($project->checkDatasourceConfig() === false) {
             $this->abort();
         }
-
-        // review `applications`
         if ($project->reviewApplications() === false) {
             $this->abort();
         }
-
-        // review `users`
         if ($project->reviewUsers() === false) {
             $this->abort();
         }
-
         $io->success('Import project done.');
         $io->out('End');
 

--- a/src/Command/ImportProjectCommand.php
+++ b/src/Command/ImportProjectCommand.php
@@ -60,7 +60,9 @@ class ImportProjectCommand extends Command
         }
 
         // review `applications`
-        $this->Applications = $this->fetchTable('Applications');
+        /** @var \BEdita\Core\Model\Table\ApplicationsTable $applications */
+        $applications = $this->fetchTable('Applications');
+        $this->Applications = $applications;
         $current = $this->loadApplications($defaultConnection);
         $import = $this->loadApplications($importConnection);
         $missing = array_diff(array_keys($import), array_keys($current));
@@ -72,7 +74,9 @@ class ImportProjectCommand extends Command
         $this->updateApplications($importConnection, $update);
 
         // review `users`
-        $this->Users = $this->fetchTable('Users');
+        /** @var \BEdita\Core\Model\Table\UsersTable $users */
+        $users = $this->fetchTable('Users');
+        $this->Users = $users;
         $current = $this->loadUsers($defaultConnection);
         $import = $this->loadUsers($importConnection);
         $missing = array_diff(array_keys($import), array_keys($current));

--- a/src/Command/ImportProjectCommand.php
+++ b/src/Command/ImportProjectCommand.php
@@ -18,7 +18,6 @@ use BEdita\ImportTools\Utility\Project;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
-use Cake\Datasource\ConnectionManager;
 
 /**
  * Command to prepare `applications` and `users` to import a project in a new environment.
@@ -44,23 +43,20 @@ class ImportProjectCommand extends Command
     public function execute(Arguments $args, ConsoleIo $io)
     {
         $io->out('Start');
-        $project = new Project();
+        $project = new Project($io);
 
         // check connection
-        if (!$project->checkDatasourceConfig($io)) {
+        if ($project->checkDatasourceConfig() === false) {
             $this->abort();
         }
 
-        $importConnection = ConnectionManager::get('import');
-        $defaultConnection = ConnectionManager::get('default');
-
         // review `applications`
-        if ($project->reviewApplications($importConnection, $defaultConnection, $io) === false) {
+        if ($project->reviewApplications() === false) {
             $this->abort();
         }
 
         // review `users`
-        if ($project->reviewUsers($importConnection, $defaultConnection, $io) === false) {
+        if ($project->reviewUsers() === false) {
             $this->abort();
         }
 

--- a/src/Command/ImportProjectCommand.php
+++ b/src/Command/ImportProjectCommand.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\ImportTools\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Database\Connection;
+use Cake\Datasource\ConnectionManager;
+use Cake\Utility\Hash;
+
+/**
+ * Command to prepare `applications` and `users` to import a project in a new environment.
+ * Since applications api keys and users passwords will generally differ this command will try to
+ * sync those values, when possible, in order to enable migration.
+ *
+ * The new project database you want to import must be reachable via an `import` key Datasource configuration.
+ * This new project will be modified this way:
+ *  - new project `applications` must be present as name on the current project DB => current api keys are saved in the new imported project
+ *  - users password hashes are changed (if set) in the new imported project using current users password hashes on records with the same `username`
+ *
+ * After this command is finished the new imported project can be used in the current environment and replace current project/database.
+ *
+ * @property \BEdita\Core\Model\Table\ApplicationsTable $Applications
+ * @property \BEdita\Core\Model\Table\UsersTable $Users
+ */
+class ImportProjectCommand extends Command
+{
+    /**
+     * {@inheritDoc}
+     *
+     * Main command execution:
+     * - applications and users are loaded from current and imported project
+     * - applications api keys and users passwords are updated to be used in current environment
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        $io->out('Start');
+        if (!in_array('import', ConnectionManager::configured())) {
+            $io->error('Unable to connect to `import` datasource, please review "Datasource" configuration');
+            $this->abort();
+        }
+        $importConnection = ConnectionManager::get('import');
+        $defaultConnection = ConnectionManager::get('default');
+        if (!$importConnection instanceof Connection || !$defaultConnection instanceof Connection) {
+            $io->error('Wrong connection type, please review "Datasource" configuration');
+            $this->abort();
+        }
+
+        // review `applications`
+        $this->Applications = $this->fetchTable('Applications');
+        $current = $this->loadApplications($defaultConnection);
+        $import = $this->loadApplications($importConnection);
+        $missing = array_diff(array_keys($import), array_keys($current));
+        if (!empty($missing)) {
+            $io->error(sprintf('Some applications are missing on current project: %s', implode(' ', $missing)));
+            $this->abort();
+        }
+        $update = array_intersect_key($current, $import);
+        $this->updateApplications($importConnection, $update);
+
+        // review `users`
+        $this->Users = $this->fetchTable('Users');
+        $current = $this->loadUsers($defaultConnection);
+        $import = $this->loadUsers($importConnection);
+        $missing = array_diff(array_keys($import), array_keys($current));
+        if (!empty($missing)) {
+            $io->warning(sprintf('Some users are missing in current project [%d]', count($missing)));
+
+            if ($io->askChoice('Do you want to proceed?', ['y', 'n'], 'n') === 'n') {
+                $io->error('Aborting.');
+                $this->abort();
+            }
+        }
+        $update = array_intersect_key($current, $import);
+        $this->updateUsers($importConnection, $update);
+        $io->success('Import project done.');
+        $io->out('End');
+    }
+
+    /**
+     * Load applications on a given connection
+     * Return an array having `name` as key,
+     *
+     * @param \Cake\Database\Connection $connection The Connection
+     * @return array
+     */
+    protected function loadApplications(Connection $connection): array
+    {
+        $this->Applications->setConnection($connection);
+        $apps = $this->Applications->find()->select(['name', 'api_key', 'client_secret'])->toArray();
+
+        return Hash::combine($apps, '{n}.name', '{n}');
+    }
+
+    /**
+     * Load users on a given connection
+     * Return an array having `username` as key,
+     *
+     * @param \Cake\Database\Connection $connection The Connection
+     * @return array
+     */
+    protected function loadUsers(Connection $connection): array
+    {
+        $this->Users->setConnection($connection);
+        $users = $this->Users->find()->select(['username', 'password_hash'])->toArray();
+
+        return Hash::combine($users, '{n}.username', '{n}');
+    }
+
+    /**
+     * Update applications api keys using api keys provided in input array
+     *
+     * @param \Cake\Database\Connection $connection The connection
+     * @param array $applications Application data
+     * @return void
+     */
+    protected function updateApplications(Connection $connection, array $applications): void
+    {
+        $this->Applications->setConnection($connection);
+        foreach ($applications as $name => $application) {
+            /** @var \BEdita\Core\Model\Entity\Application $entity */
+            $entity = $this->Applications->find()->where(['name' => $name])->firstOrFail();
+            $entity->api_key = $application->api_key;
+            $entity->client_secret = $application->client_secret;
+            $this->Applications->saveOrFail($entity);
+        }
+    }
+
+    /**
+     * Update applications api keys using api keys provided in input array
+     *
+     * @param \Cake\Database\Connection $connection The connection
+     * @param array $users Users data
+     * @return void
+     */
+    protected function updateUsers(Connection $connection, array $users): void
+    {
+        foreach ($users as $username => $user) {
+            if (empty($user->password_hash)) {
+                continue;
+            }
+            $query = sprintf(
+                "UPDATE users SET password_hash = '%s' WHERE username = '%s'",
+                $user->password_hash,
+                $username
+            );
+            $connection->execute($query);
+        }
+    }
+}

--- a/src/Utility/Project.php
+++ b/src/Utility/Project.php
@@ -1,0 +1,202 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\ImportTools\Utility;
+
+use Cake\Console\ConsoleIo;
+use Cake\Database\Connection;
+use Cake\Datasource\ConnectionManager;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\Utility\Hash;
+
+/**
+ * Project utility
+ */
+class Project
+{
+    use LocatorAwareTrait;
+
+    /**
+     * @var \BEdita\Core\Model\Table\ApplicationsTable
+     */
+    protected $Applications;
+
+    /**
+     * @var \BEdita\Core\Model\Table\UsersTable
+     */
+    protected $Users;
+
+    /**
+     * Constructor
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        /** @var \BEdita\Core\Model\Table\ApplicationsTable $applications */
+        $applications = $this->fetchTable('Applications');
+        $this->Applications = $applications;
+
+        /** @var \BEdita\Core\Model\Table\UsersTable $users */
+        $users = $this->fetchTable('Users');
+        $this->Users = $users;
+    }
+
+    /**
+     * Check if `import` and `default` datasources are correctly configured
+     *
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return bool
+     */
+    public function checkDatasourceConfig(ConsoleIo $io): bool
+    {
+        if (!in_array('import', ConnectionManager::configured())) {
+            $io->error('Unable to connect to `import` datasource, please review "Datasource" configuration');
+
+            return false;
+        }
+        $importConnection = ConnectionManager::get('import');
+        $defaultConnection = ConnectionManager::get('default');
+        if (!$importConnection instanceof Connection || !$defaultConnection instanceof Connection) {
+            $io->error('Wrong connection type, please review "Datasource" configuration');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Load applications on a given connection
+     * Return an array having `name` as key,
+     *
+     * @param \Cake\Database\Connection $connection The Connection
+     * @return array
+     */
+    public function loadApplications(Connection $connection): array
+    {
+        $this->Applications->setConnection($connection);
+        $apps = $this->Applications->find()->select(['name', 'api_key', 'client_secret'])->toArray();
+
+        return Hash::combine($apps, '{n}.name', '{n}');
+    }
+
+    /**
+     * Load users on a given connection
+     * Return an array having `username` as key,
+     *
+     * @param \Cake\Database\Connection $connection The Connection
+     * @return array
+     */
+    public function loadUsers(Connection $connection): array
+    {
+        $this->Users->setConnection($connection);
+        $users = $this->Users->find()->select(['username', 'password_hash'])->toArray();
+
+        return Hash::combine($users, '{n}.username', '{n}');
+    }
+
+    /**
+     * Update applications api keys using api keys provided in input array
+     *
+     * @param \Cake\Database\Connection $connection The connection
+     * @param array $applications Application data
+     * @return void
+     */
+    public function updateApplications(Connection $connection, array $applications): void
+    {
+        $this->Applications->setConnection($connection);
+        foreach ($applications as $name => $application) {
+            /** @var \BEdita\Core\Model\Entity\Application $entity */
+            $entity = $this->Applications->find()->where(['name' => $name])->firstOrFail();
+            $entity->api_key = $application->api_key;
+            $entity->client_secret = $application->client_secret;
+            $this->Applications->saveOrFail($entity);
+        }
+    }
+
+    /**
+     * Update applications api keys using api keys provided in input array
+     *
+     * @param \Cake\Database\Connection $connection The connection
+     * @param array $users Users data
+     * @return void
+     */
+    public function updateUsers(Connection $connection, array $users): void
+    {
+        foreach ($users as $username => $user) {
+            if (empty($user->password_hash)) {
+                continue;
+            }
+            $query = sprintf(
+                "UPDATE users SET password_hash = '%s' WHERE username = '%s'",
+                $user->password_hash,
+                $username
+            );
+            $connection->execute($query);
+        }
+    }
+
+    /**
+     * Review applications and update api keys
+     *
+     * @param \Cake\Database\Connection $defaultConnection The default connection
+     * @param \Cake\Database\Connection $importConnection The import connection
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return bool
+     */
+    public function reviewApplications(Connection $defaultConnection, Connection $importConnection, ConsoleIo $io): bool
+    {
+        $current = $this->loadApplications($defaultConnection);
+        $import = $this->loadApplications($importConnection);
+        $missing = array_diff(array_keys($import), array_keys($current));
+        if (!empty($missing)) {
+            $io->error(sprintf('Some applications are missing on current project: %s', implode(' ', $missing)));
+
+            return false;
+        }
+        $update = array_intersect_key($current, $import);
+        $this->updateApplications($importConnection, $update);
+
+        return true;
+    }
+
+    /**
+     * Review users and update password hashes
+     *
+     * @param \Cake\Database\Connection $defaultConnection The default connection
+     * @param \Cake\Database\Connection $importConnection The import connection
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @return bool
+     */
+    public function reviewUsers(Connection $defaultConnection, Connection $importConnection, ConsoleIo $io): bool
+    {
+        $current = $this->loadUsers($defaultConnection);
+        $import = $this->loadUsers($importConnection);
+        $missing = array_diff(array_keys($import), array_keys($current));
+        if (!empty($missing)) {
+            $io->warning(sprintf('Some users are missing in current project [%d]', count($missing)));
+            if ($io->askChoice('Do you want to proceed?', ['y', 'n'], 'n') === 'n') {
+                $io->error('Aborting.');
+
+                return false;
+            }
+        }
+        $update = array_intersect_key($current, $import);
+        $this->updateUsers($importConnection, $update);
+
+        return true;
+    }
+}

--- a/tests/TestCase/Command/ImportProjectCommandTest.php
+++ b/tests/TestCase/Command/ImportProjectCommandTest.php
@@ -56,5 +56,6 @@ class ImportProjectCommandTest extends TestCase
     {
         $this->exec(sprintf('import_project'));
         $this->assertOutputContains('Start');
+        $this->assertExitError('Unable to connect to `import` datasource, please review "Datasource" configuration');
     }
 }

--- a/tests/TestCase/Command/ImportProjectCommandTest.php
+++ b/tests/TestCase/Command/ImportProjectCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\ImportTools\Test\TestCase\Command;
+
+use BEdita\ImportTools\Command\ImportProjectCommand;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\ImportTools\Command\ImportProjectCommand} Test Case
+ *
+ * @coversDefaultClass \BEdita\ImportTools\Command\ImportProjectCommand
+ */
+class ImportProjectCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * The command used in test
+     *
+     * @var \BEdita\ImportTools\Command\ImportProjectCommand
+     */
+    protected $command = null;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+        $this->command = new ImportProjectCommand();
+    }
+
+    /**
+     * Test execute method
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecute(): void
+    {
+        $this->exec(sprintf('import_project'));
+        $this->assertOutputContains('Start');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -102,7 +102,6 @@ ConnectionManager::alias('test', 'default');
 ConnectionManager::setConfig('test-import', ['url' => getenv('db_dsn')]);
 ConnectionManager::alias('test-import', 'import');
 
-
 if (!TableRegistry::getTableLocator() instanceof TableLocator) {
     TableRegistry::setTableLocator(new TableLocator());
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -99,6 +99,9 @@ if (!getenv('db_dsn')) {
 }
 ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);
 ConnectionManager::alias('test', 'default');
+ConnectionManager::setConfig('test-import', ['url' => getenv('db_dsn')]);
+ConnectionManager::alias('test-import', 'import');
+
 
 if (!TableRegistry::getTableLocator() instanceof TableLocator) {
     TableRegistry::setTableLocator(new TableLocator());


### PR DESCRIPTION
This introduces `ImportProjectCommand`.
You could use this command when you are copying a remote database to a locale database, and after that you want to "adjust" applications and users.
You can copy BEdita project applications and users from one connection into another by using `bin/cake import_project`.
Applications and users in default datasource will be updated.

Before launching it, you should setup properly `default` and `import` datasources in `config/app_local.php`.
Example:
```php
'Datasources' => [
    // the target database 
    'default' => [
        'className' => 'Cake\Database\Connection',
        'driver' => 'Cake\Database\Driver\Mysql',
        'host' => '***********',
        'port' => '***********',
        'username' => '***********',
        'password' => '***********',
        'database' => '***********',
        // ...
    ],
    // the remote database you want to you as source
    'import' => [
        'className' => 'Cake\Database\Connection',
        'driver' => 'Cake\Database\Driver\Mysql',
        'host' => '***********',
        'port' => '***********',
        'username' => '***********',
        'password' => '***********',
        'database' => '***********',
        // ...
    ],
],
```