### PR TITLE
fix: use actual type for $this->typeTable

### DIFF
--- a/src/Utility/Import.php
+++ b/src/Utility/Import.php
@@ -229,27 +229,11 @@ class Import
         $this->skipped = 0;
         $this->errorsDetails = [];
         $this->objectsTable = $this->fetchTable('objects'); // @phpstan-ignore-line
-        if ($this->objectTypeExists($type)) {
-            $this->typeTable = $this->fetchTable($type); // @phpstan-ignore-line
+        $typeTable = $this->fetchTable($type);
+        if ($typeTable instanceof ObjectsTable || $typeTable instanceof ObjectsBaseTable) {
+            $this->typeTable = $typeTable;
         }
         $this->translationsTable = $this->fetchTable('translations'); // @phpstan-ignore-line
-    }
-
-    /**
-     * Check if an object type exists
-     *
-     * @param string $type Object type name
-     * @return bool True if object type exists, false otherwise
-     */
-    protected function objectTypeExists(string $type): bool
-    {
-        try {
-            $this->fetchTable('ObjectTypes')->get($type);
-        } catch (Exception) {
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/src/Utility/Import.php
+++ b/src/Utility/Import.php
@@ -229,8 +229,27 @@ class Import
         $this->skipped = 0;
         $this->errorsDetails = [];
         $this->objectsTable = $this->fetchTable('objects'); // @phpstan-ignore-line
-        $this->typeTable = $this->fetchTable($this->type); // @phpstan-ignore-line
+        if ($this->objectTypeExists($type)) {
+            $this->typeTable = $this->fetchTable($type); // @phpstan-ignore-line
+        }
         $this->translationsTable = $this->fetchTable('translations'); // @phpstan-ignore-line
+    }
+
+    /**
+     * Check if an object type exists
+     *
+     * @param string $type Object type name
+     * @return bool True if object type exists, false otherwise
+     */
+    protected function objectTypeExists(string $type): bool
+    {
+        try {
+            $this->fetchTable('ObjectTypes')->get($type);
+        } catch (Exception) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -297,6 +316,9 @@ class Import
      */
     public function saveObject(array $obj): ObjectEntity
     {
+        if (empty($this->typeTable)) {
+            throw new BadRequestException(sprintf('Object type "%s" not found', $this->type));
+        }
         /** @var \BEdita\Core\Model\Entity\ObjectEntity $entity */
         $entity = $this->typeTable->newEmptyEntity();
         if (!empty($obj['uname']) || !empty($obj['id'])) {

--- a/src/Utility/Import.php
+++ b/src/Utility/Import.php
@@ -228,14 +228,9 @@ class Import
         $this->errors = 0;
         $this->skipped = 0;
         $this->errorsDetails = [];
-        /** @var \BEdita\Core\Model\Table\ObjectsTable $objectsTable */
-        $objectsTable = $this->fetchTable('objects');
-        $this->objectsTable = $objectsTable;
-        $typesTable = $this->fetchTable($this->type);
-        $this->typeTable = $typesTable instanceof ObjectsBaseTable ? $typesTable : $objectsTable;
-        /** @var \BEdita\Core\Model\Table\TranslationsTable $translationsTable */
-        $translationsTable = $this->fetchTable('translations');
-        $this->translationsTable = $translationsTable;
+        $this->objectsTable = $this->fetchTable('objects');  // @phpstan-ignore-line
+        $this->typeTable = $this->fetchTable($this->type); // @phpstan-ignore-line
+        $this->translationsTable = $this->fetchTable('translations'); // @phpstan-ignore-line
     }
 
     /**

--- a/src/Utility/Import.php
+++ b/src/Utility/Import.php
@@ -228,7 +228,7 @@ class Import
         $this->errors = 0;
         $this->skipped = 0;
         $this->errorsDetails = [];
-        $this->objectsTable = $this->fetchTable('objects');  // @phpstan-ignore-line
+        $this->objectsTable = $this->fetchTable('objects'); // @phpstan-ignore-line
         $this->typeTable = $this->fetchTable($this->type); // @phpstan-ignore-line
         $this->translationsTable = $this->fetchTable('translations'); // @phpstan-ignore-line
     }


### PR DESCRIPTION
This PR improves the robustness of the object import process by ensuring that only valid object types are used and by handling cases where an object type does not exist and avoiding `ObjectsTable` direct usage on types extending objects directly. 

**Initialization and object type validation:**
- Refactored the constructor in `Import.php` to set the `typeTable` property only to valid and actual types

**Error handling improvements:**
- Updated the `saveObject` method to throw a `BadRequestException` if the `typeTable` is not set, providing a clear error message when an invalid object type is encountered.